### PR TITLE
Remove root redirect and serve calculators at site root

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,45 +2,417 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Redirecting to calculators | calchowmuch.com</title>
+    <title>Calculators | calchowmuch.com</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Redirecting to calculators on calchowmuch.com" />
-    <meta http-equiv="refresh" content="0; url=/calculators/" />
+    <meta name="description" content="Simple, fast calculators on calchowmuch.com" />
     <style>
       :root {
         color-scheme: light;
         font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-        background: #f6f7fb;
-        color: #1f2937;
       }
 
       body {
         margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
+        background: #f6f7fb;
+        color: #1f2937;
+      }
+
+      header {
+        padding: 24px 32px;
+        background: #111827;
+        color: #f9fafb;
+      }
+
+      header h1 {
+        margin: 0 0 4px;
+        font-size: 24px;
+      }
+
+      header p {
+        margin: 0;
+        color: #d1d5db;
       }
 
       main {
-        text-align: center;
-        padding: 24px;
+        display: grid;
+        grid-template-columns: 260px minmax(0, 1fr);
+        gap: 24px;
+        padding: 32px;
+        max-width: 1100px;
+        margin: 0 auto;
       }
 
-      a {
-        color: #2563eb;
+      aside {
+        background: #ffffff;
+        border-radius: 16px;
+        padding: 20px;
+        box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+        height: fit-content;
+      }
+
+      aside h2 {
+        margin-top: 0;
+        margin-bottom: 24px;
+        font-size: 20px;
+        color: #111827;
+      }
+
+      .category {
+        margin-bottom: 20px;
+      }
+
+      .category h3 {
+        margin: 0 0 12px 0;
+        font-size: 15px;
+        color: #6b7280;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        font-weight: 600;
+      }
+
+      .calculator-list {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      .calculator-option {
+        display: flex;
+        align-items: center;
+        padding: 10px 12px;
+        border-radius: 10px;
+        cursor: pointer;
+        transition: background-color 0.2s;
+      }
+
+      .calculator-option:hover {
+        background: #f3f4f6;
+      }
+
+      .calculator-option input[type="radio"] {
+        margin-right: 10px;
+        width: 18px;
+        height: 18px;
+        cursor: pointer;
+      }
+
+      .calculator-option span {
+        font-size: 15px;
+        color: #374151;
+        font-weight: 500;
+      }
+
+      .calculator-panel {
+        background: #ffffff;
+        border-radius: 20px;
+        padding: 28px;
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        align-items: center;
+      }
+
+      .calculator-panel h2 {
+        margin: 0;
+        font-size: 22px;
+      }
+
+      .calc-grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+        width: 100%;
+        max-width: 420px;
+      }
+
+      label {
+        font-size: 14px;
+        color: #6b7280;
+      }
+
+      input[type="number"] {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid #d1d5db;
+        font-size: 16px;
+      }
+
+      .button-row {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 10px;
+        width: 100%;
+        max-width: 420px;
+      }
+
+      button {
+        padding: 10px;
+        border-radius: 10px;
+        border: none;
+        background: #2563eb;
+        color: #ffffff;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      button.secondary {
+        background: #e5e7eb;
+        color: #111827;
+      }
+
+      .result {
+        font-size: 20px;
+        font-weight: 600;
+        color: #111827;
+      }
+
+      .helper {
+        margin: 0;
+        color: #6b7280;
+        text-align: center;
+      }
+
+      .percentage-section {
+        width: 100%;
+        max-width: 520px;
+        padding: 24px;
+        background: #f9fafb;
+        border-radius: 12px;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        align-items: center;
+      }
+
+      .calc-title {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 500;
+        color: #374151;
+        line-height: 1.6;
+        text-align: center;
+      }
+
+      .inline-input {
+        width: 80px;
+        padding: 6px 10px;
+        border-radius: 8px;
+        border: 1px solid #d1d5db;
+        font-size: 16px;
+        text-align: center;
+        display: inline-block;
+        margin: 0 4px;
+      }
+
+      .calc-button {
+        padding: 10px 24px;
+        border-radius: 10px;
+        border: none;
+        background: #2563eb;
+        color: #ffffff;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 15px;
+      }
+
+      .calc-button:hover {
+        background: #1d4ed8;
+      }
+
+      /* Loading skeleton styles */
+      .skeleton-loader {
+        background: #ffffff;
+        border-radius: 20px;
+        padding: 28px;
+        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.1);
+        display: flex;
+        flex-direction: column;
+        gap: 20px;
+        align-items: center;
+        min-height: 400px;
+      }
+
+      .skeleton-item {
+        background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+        background-size: 200% 100%;
+        animation: loading 1.5s infinite;
+        border-radius: 8px;
+      }
+
+      .skeleton-title {
+        width: 200px;
+        height: 28px;
+        margin-bottom: 10px;
+      }
+
+      .skeleton-text {
+        width: 300px;
+        height: 20px;
+        margin-bottom: 20px;
+      }
+
+      .skeleton-input {
+        width: 100%;
+        max-width: 420px;
+        height: 80px;
+        margin-bottom: 10px;
+      }
+
+      .skeleton-button {
+        width: 100%;
+        max-width: 420px;
+        height: 40px;
+      }
+
+      @keyframes loading {
+        0% {
+          background-position: 200% 0;
+        }
+        100% {
+          background-position: -200% 0;
+        }
+      }
+
+      @media (max-width: 860px) {
+        main {
+          grid-template-columns: 1fr;
+        }
+
+        aside {
+          order: 2;
+        }
       }
     </style>
-    <script>
-      window.location.replace("/calculators/");
-    </script>
   </head>
   <body>
+    <header>
+      <h1>Calculate How Much</h1>
+      <p>Select a calculator from the left sidebar and start calculating.</p>
+    </header>
+
     <main>
-      <p>
-        Redirecting to the calculators landing page.
-        <a href="/calculators/">Open calculators</a>
-      </p>
+      <aside>
+        <h2>Calculate How Much</h2>
+        <div id="categories-container">
+          <!-- Categories and calculators will be dynamically loaded here -->
+        </div>
+      </aside>
+
+      <div id="calculator-container">
+        <!-- Loading skeleton -->
+        <div class="skeleton-loader">
+          <div class="skeleton-item skeleton-title"></div>
+          <div class="skeleton-item skeleton-text"></div>
+          <div class="skeleton-item skeleton-input"></div>
+          <div class="skeleton-item skeleton-button"></div>
+        </div>
+      </div>
     </main>
+
+    <!-- Load configuration -->
+    <script src="calculators/calculators-config.js"></script>
+
+    <script>
+      // State to track loaded calculators
+      const loadedCalculators = {};
+      let currentCalculatorId = null;
+
+      // Function to load a calculator HTML file
+      async function loadCalculator(calculatorId, fileName) {
+        // Check if calculator is already loaded
+        if (loadedCalculators[calculatorId]) {
+          showCalculator(calculatorId);
+          return;
+        }
+
+        try {
+          const response = await fetch(`calculators/${fileName}`);
+          const html = await response.text();
+
+          // Create a temporary container to parse the HTML
+          const tempDiv = document.createElement('div');
+          tempDiv.innerHTML = html;
+
+          // Store the calculator content
+          loadedCalculators[calculatorId] = tempDiv.innerHTML;
+
+          // Show the calculator
+          showCalculator(calculatorId);
+        } catch (error) {
+          console.error(`Error loading calculator ${calculatorId}:`, error);
+          document.getElementById('calculator-container').innerHTML =
+            '<div class="calculator-panel"><h2>Error loading calculator</h2></div>';
+        }
+      }
+
+      // Function to show a specific calculator
+      function showCalculator(calculatorId) {
+        currentCalculatorId = calculatorId;
+        const container = document.getElementById('calculator-container');
+        container.innerHTML = loadedCalculators[calculatorId];
+
+        // Execute any scripts in the loaded calculator
+        const scripts = container.querySelectorAll('script');
+        scripts.forEach(script => {
+          const newScript = document.createElement('script');
+          newScript.textContent = script.textContent;
+          script.parentNode.replaceChild(newScript, script);
+        });
+      }
+
+      // Function to generate sidebar from config
+      function generateSidebar() {
+        const container = document.getElementById('categories-container');
+        let isFirst = true;
+
+        calculatorsConfig.categories.forEach(category => {
+          const categoryDiv = document.createElement('div');
+          categoryDiv.className = 'category';
+
+          const categoryTitle = document.createElement('h3');
+          categoryTitle.textContent = category.name;
+          categoryDiv.appendChild(categoryTitle);
+
+          const calculatorList = document.createElement('div');
+          calculatorList.className = 'calculator-list';
+
+          category.calculators.forEach(calc => {
+            const label = document.createElement('label');
+            label.className = 'calculator-option';
+
+            const radio = document.createElement('input');
+            radio.type = 'radio';
+            radio.name = 'calculator';
+            radio.value = calc.id;
+            radio.checked = isFirst;
+
+            radio.addEventListener('change', () => {
+              loadCalculator(calc.id, calc.file);
+            });
+
+            const span = document.createElement('span');
+            span.textContent = calc.name;
+
+            label.appendChild(radio);
+            label.appendChild(span);
+            calculatorList.appendChild(label);
+
+            // Load the first calculator by default
+            if (isFirst) {
+              loadCalculator(calc.id, calc.file);
+              isFirst = false;
+            }
+          });
+
+          categoryDiv.appendChild(calculatorList);
+          container.appendChild(categoryDiv);
+        });
+      }
+
+      // Initialize the sidebar when page loads
+      document.addEventListener('DOMContentLoaded', generateSidebar);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Remove the old redirect logic so the site root serves the calculators landing page directly and avoids the flash/instability caused by redirection.  
- Simplify routing by serving the new UI at `/` instead of redirecting to `/calculators/`.  
- Ensure the root page loads calculator assets from their actual `calculators` location without client-side redirects.  

### Description
- Replaced `public/index.html` content to remove the `<meta http-equiv="refresh">` and `window.location.replace` redirect and instead render the calculators landing layout.  
- Updated asset/loading paths to use `calculators/calculators-config.js` and `fetch('calculators/${fileName}')` when loading individual calculator HTML files.  
- Kept the client-side sidebar generation and lazy-loading logic for calculators (skeleton loader, `loadCalculator`, `showCalculator`, and `generateSidebar`).  

### Testing
- Served the modified `public` directory with `python -m http.server 8000` and loaded `http://127.0.0.1:8000/` with a Playwright script to confirm the root page renders the calculators landing layout, and the run produced a screenshot successfully.  
- No automated unit tests were executed because this is a static HTML/JS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963fcead01083259ae6cfccb0ea9327)