### PR TITLE
Phase 1: Add layout shell and placeholder assets

### DIFF
--- a/public/assets/css/base.css
+++ b/public/assets/css/base.css
@@ -1,0 +1,33 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --page-bg: #f6f7fb;
+  --panel-bg: #ffffff;
+  --header-bg: #0f172a;
+  --header-text: #f8fafc;
+  --muted-text: #6b7280;
+  --border-color: #e2e8f0;
+  --panel-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  --header-height: 72px;
+  --nav-height: 56px;
+  --footer-height: 64px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page-bg);
+  color: #0f172a;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}

--- a/public/assets/css/layout.css
+++ b/public/assets/css/layout.css
@@ -1,0 +1,148 @@
+.page {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: var(--header-height) var(--nav-height) 1fr var(--footer-height);
+}
+
+.site-header {
+  background: var(--header-bg);
+  color: var(--header-text);
+  display: flex;
+  align-items: center;
+  padding: 0 32px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+.top-nav {
+  background: #111827;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.top-nav button {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #f8fafc;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-size: 14px;
+}
+
+.layout-main {
+  display: grid;
+  grid-template-columns: 240px minmax(0, 1fr) 240px;
+  gap: 20px;
+  padding: 20px 32px;
+  min-height: 0;
+}
+
+.left-nav {
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 16px;
+  box-shadow: var(--panel-shadow);
+  padding: 16px;
+  overflow-y: auto;
+}
+
+.left-nav h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.left-nav .nav-item {
+  background: #f1f5f9;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: var(--muted-text);
+  margin-bottom: 8px;
+}
+
+.center-column {
+  display: grid;
+  grid-template-rows: minmax(220px, 1fr) minmax(220px, 1fr);
+  gap: 20px;
+  min-height: 0;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 20px;
+  box-shadow: var(--panel-shadow);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.panel h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.panel .placeholder {
+  color: var(--muted-text);
+  font-size: 14px;
+}
+
+.ads-column {
+  display: grid;
+  grid-template-rows: minmax(220px, 1fr) minmax(220px, 1fr);
+  gap: 20px;
+  min-height: 0;
+}
+
+.ad-panel {
+  background: #f8fafc;
+  border: 1px dashed #cbd5f5;
+  border-radius: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted-text);
+  font-size: 14px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border-color);
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  color: var(--muted-text);
+  font-size: 14px;
+}
+
+.site-footer a {
+  color: var(--muted-text);
+}
+
+@media (max-width: 1024px) {
+  .layout-main {
+    grid-template-columns: 200px minmax(0, 1fr) 200px;
+    padding: 20px;
+  }
+}
+
+@media (max-width: 860px) {
+  .page {
+    grid-template-rows: var(--header-height) var(--nav-height) auto var(--footer-height);
+  }
+
+  .layout-main {
+    grid-template-columns: 1fr;
+  }
+
+  .ads-column {
+    grid-template-rows: minmax(180px, 1fr) minmax(180px, 1fr);
+  }
+}

--- a/public/assets/js/core/dom.js
+++ b/public/assets/js/core/dom.js
@@ -1,0 +1,1 @@
+// Core DOM utilities will be added in later phases.

--- a/public/assets/js/core/state.js
+++ b/public/assets/js/core/state.js
@@ -1,0 +1,1 @@
+// Global state management will be added in later phases.

--- a/public/index.html
+++ b/public/index.html
@@ -2,417 +2,61 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Calculators | calchowmuch.com</title>
+    <title>Calculate How Much</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Simple, fast calculators on calchowmuch.com" />
-    <style>
-      :root {
-        color-scheme: light;
-        font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
-      }
-
-      body {
-        margin: 0;
-        background: #f6f7fb;
-        color: #1f2937;
-      }
-
-      header {
-        padding: 24px 32px;
-        background: #111827;
-        color: #f9fafb;
-      }
-
-      header h1 {
-        margin: 0 0 4px;
-        font-size: 24px;
-      }
-
-      header p {
-        margin: 0;
-        color: #d1d5db;
-      }
-
-      main {
-        display: grid;
-        grid-template-columns: 260px minmax(0, 1fr);
-        gap: 24px;
-        padding: 32px;
-        max-width: 1100px;
-        margin: 0 auto;
-      }
-
-      aside {
-        background: #ffffff;
-        border-radius: 16px;
-        padding: 20px;
-        box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
-        height: fit-content;
-      }
-
-      aside h2 {
-        margin-top: 0;
-        margin-bottom: 24px;
-        font-size: 20px;
-        color: #111827;
-      }
-
-      .category {
-        margin-bottom: 20px;
-      }
-
-      .category h3 {
-        margin: 0 0 12px 0;
-        font-size: 15px;
-        color: #6b7280;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        font-weight: 600;
-      }
-
-      .calculator-list {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-      }
-
-      .calculator-option {
-        display: flex;
-        align-items: center;
-        padding: 10px 12px;
-        border-radius: 10px;
-        cursor: pointer;
-        transition: background-color 0.2s;
-      }
-
-      .calculator-option:hover {
-        background: #f3f4f6;
-      }
-
-      .calculator-option input[type="radio"] {
-        margin-right: 10px;
-        width: 18px;
-        height: 18px;
-        cursor: pointer;
-      }
-
-      .calculator-option span {
-        font-size: 15px;
-        color: #374151;
-        font-weight: 500;
-      }
-
-      .calculator-panel {
-        background: #ffffff;
-        border-radius: 20px;
-        padding: 28px;
-        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.1);
-        display: flex;
-        flex-direction: column;
-        gap: 20px;
-        align-items: center;
-      }
-
-      .calculator-panel h2 {
-        margin: 0;
-        font-size: 22px;
-      }
-
-      .calc-grid {
-        display: grid;
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        gap: 16px;
-        width: 100%;
-        max-width: 420px;
-      }
-
-      label {
-        font-size: 14px;
-        color: #6b7280;
-      }
-
-      input[type="number"] {
-        width: 100%;
-        padding: 10px 12px;
-        border-radius: 10px;
-        border: 1px solid #d1d5db;
-        font-size: 16px;
-      }
-
-      .button-row {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 10px;
-        width: 100%;
-        max-width: 420px;
-      }
-
-      button {
-        padding: 10px;
-        border-radius: 10px;
-        border: none;
-        background: #2563eb;
-        color: #ffffff;
-        font-weight: 600;
-        cursor: pointer;
-      }
-
-      button.secondary {
-        background: #e5e7eb;
-        color: #111827;
-      }
-
-      .result {
-        font-size: 20px;
-        font-weight: 600;
-        color: #111827;
-      }
-
-      .helper {
-        margin: 0;
-        color: #6b7280;
-        text-align: center;
-      }
-
-      .percentage-section {
-        width: 100%;
-        max-width: 520px;
-        padding: 24px;
-        background: #f9fafb;
-        border-radius: 12px;
-        display: flex;
-        flex-direction: column;
-        gap: 16px;
-        align-items: center;
-      }
-
-      .calc-title {
-        margin: 0;
-        font-size: 18px;
-        font-weight: 500;
-        color: #374151;
-        line-height: 1.6;
-        text-align: center;
-      }
-
-      .inline-input {
-        width: 80px;
-        padding: 6px 10px;
-        border-radius: 8px;
-        border: 1px solid #d1d5db;
-        font-size: 16px;
-        text-align: center;
-        display: inline-block;
-        margin: 0 4px;
-      }
-
-      .calc-button {
-        padding: 10px 24px;
-        border-radius: 10px;
-        border: none;
-        background: #2563eb;
-        color: #ffffff;
-        font-weight: 600;
-        cursor: pointer;
-        font-size: 15px;
-      }
-
-      .calc-button:hover {
-        background: #1d4ed8;
-      }
-
-      /* Loading skeleton styles */
-      .skeleton-loader {
-        background: #ffffff;
-        border-radius: 20px;
-        padding: 28px;
-        box-shadow: 0 18px 36px rgba(15, 23, 42, 0.1);
-        display: flex;
-        flex-direction: column;
-        gap: 20px;
-        align-items: center;
-        min-height: 400px;
-      }
-
-      .skeleton-item {
-        background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
-        background-size: 200% 100%;
-        animation: loading 1.5s infinite;
-        border-radius: 8px;
-      }
-
-      .skeleton-title {
-        width: 200px;
-        height: 28px;
-        margin-bottom: 10px;
-      }
-
-      .skeleton-text {
-        width: 300px;
-        height: 20px;
-        margin-bottom: 20px;
-      }
-
-      .skeleton-input {
-        width: 100%;
-        max-width: 420px;
-        height: 80px;
-        margin-bottom: 10px;
-      }
-
-      .skeleton-button {
-        width: 100%;
-        max-width: 420px;
-        height: 40px;
-      }
-
-      @keyframes loading {
-        0% {
-          background-position: 200% 0;
-        }
-        100% {
-          background-position: -200% 0;
-        }
-      }
-
-      @media (max-width: 860px) {
-        main {
-          grid-template-columns: 1fr;
-        }
-
-        aside {
-          order: 2;
-        }
-      }
-    </style>
+    <meta name="description" content="Layout shell for calchowmuch.com" />
+    <link rel="stylesheet" href="assets/css/base.css" />
+    <link rel="stylesheet" href="assets/css/layout.css" />
   </head>
   <body>
-    <header>
-      <h1>Calculate How Much</h1>
-      <p>Select a calculator from the left sidebar and start calculating.</p>
-    </header>
+    <div class="page">
+      <header class="site-header">
+        <span>Calculate How Much</span>
+      </header>
 
-    <main>
-      <aside>
-        <h2>Calculate How Much</h2>
-        <div id="categories-container">
-          <!-- Categories and calculators will be dynamically loaded here -->
-        </div>
-      </aside>
+      <nav class="top-nav" aria-label="Category navigation">
+        <button type="button">Category A</button>
+        <button type="button">Category B</button>
+        <button type="button">Category C</button>
+        <button type="button">Category D</button>
+      </nav>
 
-      <div id="calculator-container">
-        <!-- Loading skeleton -->
-        <div class="skeleton-loader">
-          <div class="skeleton-item skeleton-title"></div>
-          <div class="skeleton-item skeleton-text"></div>
-          <div class="skeleton-item skeleton-input"></div>
-          <div class="skeleton-item skeleton-button"></div>
-        </div>
-      </div>
-    </main>
+      <main class="layout-main">
+        <aside class="left-nav" aria-label="Left navigation">
+          <h2>Navigation</h2>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+          <div class="nav-item">Left nav item</div>
+        </aside>
 
-    <!-- Load configuration -->
-    <script src="calculators/calculators-config.js"></script>
+        <section class="center-column">
+          <div class="panel">
+            <h3>Main Calculation Pane</h3>
+            <p class="placeholder">Placeholder for calculator content.</p>
+          </div>
+          <div class="panel">
+            <h3>Explanation Pane</h3>
+            <p class="placeholder">Placeholder for explanation content.</p>
+          </div>
+        </section>
 
-    <script>
-      // State to track loaded calculators
-      const loadedCalculators = {};
-      let currentCalculatorId = null;
+        <section class="ads-column" aria-label="Ad placeholders">
+          <div class="ad-panel">Ad Pane</div>
+          <div class="ad-panel">Ad Pane</div>
+        </section>
+      </main>
 
-      // Function to load a calculator HTML file
-      async function loadCalculator(calculatorId, fileName) {
-        // Check if calculator is already loaded
-        if (loadedCalculators[calculatorId]) {
-          showCalculator(calculatorId);
-          return;
-        }
-
-        try {
-          const response = await fetch(`calculators/${fileName}`);
-          const html = await response.text();
-
-          // Create a temporary container to parse the HTML
-          const tempDiv = document.createElement('div');
-          tempDiv.innerHTML = html;
-
-          // Store the calculator content
-          loadedCalculators[calculatorId] = tempDiv.innerHTML;
-
-          // Show the calculator
-          showCalculator(calculatorId);
-        } catch (error) {
-          console.error(`Error loading calculator ${calculatorId}:`, error);
-          document.getElementById('calculator-container').innerHTML =
-            '<div class="calculator-panel"><h2>Error loading calculator</h2></div>';
-        }
-      }
-
-      // Function to show a specific calculator
-      function showCalculator(calculatorId) {
-        currentCalculatorId = calculatorId;
-        const container = document.getElementById('calculator-container');
-        container.innerHTML = loadedCalculators[calculatorId];
-
-        // Execute any scripts in the loaded calculator
-        const scripts = container.querySelectorAll('script');
-        scripts.forEach(script => {
-          const newScript = document.createElement('script');
-          newScript.textContent = script.textContent;
-          script.parentNode.replaceChild(newScript, script);
-        });
-      }
-
-      // Function to generate sidebar from config
-      function generateSidebar() {
-        const container = document.getElementById('categories-container');
-        let isFirst = true;
-
-        calculatorsConfig.categories.forEach(category => {
-          const categoryDiv = document.createElement('div');
-          categoryDiv.className = 'category';
-
-          const categoryTitle = document.createElement('h3');
-          categoryTitle.textContent = category.name;
-          categoryDiv.appendChild(categoryTitle);
-
-          const calculatorList = document.createElement('div');
-          calculatorList.className = 'calculator-list';
-
-          category.calculators.forEach(calc => {
-            const label = document.createElement('label');
-            label.className = 'calculator-option';
-
-            const radio = document.createElement('input');
-            radio.type = 'radio';
-            radio.name = 'calculator';
-            radio.value = calc.id;
-            radio.checked = isFirst;
-
-            radio.addEventListener('change', () => {
-              loadCalculator(calc.id, calc.file);
-            });
-
-            const span = document.createElement('span');
-            span.textContent = calc.name;
-
-            label.appendChild(radio);
-            label.appendChild(span);
-            calculatorList.appendChild(label);
-
-            // Load the first calculator by default
-            if (isFirst) {
-              loadCalculator(calc.id, calc.file);
-              isFirst = false;
-            }
-          });
-
-          categoryDiv.appendChild(calculatorList);
-          container.appendChild(categoryDiv);
-        });
-      }
-
-      // Initialize the sidebar when page loads
-      document.addEventListener('DOMContentLoaded', generateSidebar);
-    </script>
+      <footer class="site-footer">
+        <a href="#">Privacy</a>
+        <a href="#">Terms</a>
+        <a href="#">Contact</a>
+      </footer>
+    </div>
   </body>
 </html>

--- a/public/layout/footer.html
+++ b/public/layout/footer.html
@@ -1,0 +1,5 @@
+<footer class="site-footer">
+  <a href="#">Privacy</a>
+  <a href="#">Terms</a>
+  <a href="#">Contact</a>
+</footer>

--- a/public/layout/header.html
+++ b/public/layout/header.html
@@ -1,0 +1,3 @@
+<header class="site-header">
+  <span>Calculate How Much</span>
+</header>

--- a/public/layout/page-shell.html
+++ b/public/layout/page-shell.html
@@ -1,0 +1,49 @@
+<div class="page">
+  <header class="site-header">
+    <span>Calculate How Much</span>
+  </header>
+
+  <nav class="top-nav" aria-label="Category navigation">
+    <button type="button">Category A</button>
+    <button type="button">Category B</button>
+    <button type="button">Category C</button>
+    <button type="button">Category D</button>
+  </nav>
+
+  <main class="layout-main">
+    <aside class="left-nav">
+      <h2>Navigation</h2>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+      <div class="nav-item">Left nav item</div>
+    </aside>
+
+    <section class="center-column">
+      <div class="panel">
+        <h3>Main Calculation Pane</h3>
+        <p class="placeholder">Placeholder for calculator content.</p>
+      </div>
+      <div class="panel">
+        <h3>Explanation Pane</h3>
+        <p class="placeholder">Placeholder for explanation content.</p>
+      </div>
+    </section>
+
+    <section class="ads-column" aria-label="Ad placeholders">
+      <div class="ad-panel">Ad Pane</div>
+      <div class="ad-panel">Ad Pane</div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <a href="#">Privacy</a>
+    <a href="#">Terms</a>
+    <a href="#">Contact</a>
+  </footer>
+</div>


### PR DESCRIPTION
### Motivation

- Implement the Phase 1 global page layout shell with fixed regions and placeholders to match the provided diagram.
- Provide the required repository structure under `public` (CSS, JS core stubs, and layout fragments) for future phases.
- Ensure panes have stable sizing (min sizes and grid) to avoid layout shifts and keep ad panes as placeholders only.

### Description

- Add `public/assets/css/base.css` and `public/assets/css/layout.css` containing CSS variables and a grid-based layout for header, top nav, left nav, center panes, ads column, and footer.
- Replace the previous `public/index.html` with a static shell that links the new CSS and contains placeholder regions for Header, Top nav, Left navigation (scrollable), Main calculation pane, Explanation pane, two Ad panes, and Footer.
- Add layout fragments `public/layout/header.html`, `public/layout/footer.html`, and `public/layout/page-shell.html` plus placeholder core scripts `public/assets/js/core/dom.js` and `public/assets/js/core/state.js` for later phases.
- Use aria labels and placeholder content to satisfy accessibility and checklist requirements while avoiding any calculator or ad logic in this phase.

### Testing

- Served the `public` directory with `python -m http.server 8000` and confirmed the server started successfully.
- Ran an automated Playwright script to visit `http://127.0.0.1:8000/index.html` and capture a full-page screenshot as a visual smoke test, which completed successfully.
- No unit or integration test suites were present for this phase, so only the visual smoke test was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696559f823f88325b0ab97529e0c5c29)