### PR TITLE
Add navigation schema-driven routing for shell

### DIFF
--- a/public/assets/css/layout.css
+++ b/public/assets/css/layout.css
@@ -30,6 +30,12 @@
   padding: 8px 14px;
   border-radius: 999px;
   font-size: 14px;
+  cursor: pointer;
+}
+
+.top-nav button.is-active {
+  background: #f8fafc;
+  color: #111827;
 }
 
 .layout-main {
@@ -54,13 +60,30 @@
   font-size: 16px;
 }
 
+.left-nav .subcategory-title {
+  margin: 16px 0 8px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: #94a3b8;
+}
+
 .left-nav .nav-item {
+  width: 100%;
+  text-align: left;
   background: #f1f5f9;
   border-radius: 10px;
   padding: 10px 12px;
   font-size: 14px;
   color: var(--muted-text);
   margin-bottom: 8px;
+  border: none;
+  cursor: pointer;
+}
+
+.left-nav .nav-item.is-active {
+  background: #2563eb;
+  color: #f8fafc;
 }
 
 .center-column {

--- a/public/config/navigation.json
+++ b/public/config/navigation.json
@@ -1,0 +1,80 @@
+{
+  "categories": [
+    {
+      "id": "finance",
+      "name": "Finance",
+      "subcategories": [
+        {
+          "id": "budgeting",
+          "name": "Budgeting",
+          "calculators": [
+            {
+              "id": "savings-goal",
+              "name": "Savings Goal",
+              "url": "#/calculators/savings-goal"
+            },
+            {
+              "id": "monthly-spend",
+              "name": "Monthly Spend",
+              "url": "#/calculators/monthly-spend"
+            }
+          ]
+        },
+        {
+          "id": "borrowing",
+          "name": "Borrowing",
+          "calculators": [
+            {
+              "id": "loan-payment",
+              "name": "Loan Payment",
+              "url": "#/calculators/loan-payment"
+            },
+            {
+              "id": "credit-payoff",
+              "name": "Credit Payoff",
+              "url": "#/calculators/credit-payoff"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "health",
+      "name": "Health",
+      "subcategories": [
+        {
+          "id": "fitness",
+          "name": "Fitness",
+          "calculators": [
+            {
+              "id": "bmi-check",
+              "name": "BMI Check",
+              "url": "#/calculators/bmi-check"
+            },
+            {
+              "id": "calorie-needs",
+              "name": "Daily Calories",
+              "url": "#/calculators/calorie-needs"
+            }
+          ]
+        },
+        {
+          "id": "wellness",
+          "name": "Wellness",
+          "calculators": [
+            {
+              "id": "sleep-cycle",
+              "name": "Sleep Cycle",
+              "url": "#/calculators/sleep-cycle"
+            },
+            {
+              "id": "hydration",
+              "name": "Hydration",
+              "url": "#/calculators/hydration"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/public/index.html
+++ b/public/index.html
@@ -14,35 +14,26 @@
         <span>Calculate How Much</span>
       </header>
 
-      <nav class="top-nav" aria-label="Category navigation">
-        <button type="button">Category A</button>
-        <button type="button">Category B</button>
-        <button type="button">Category C</button>
-        <button type="button">Category D</button>
-      </nav>
+      <nav class="top-nav" aria-label="Category navigation" id="top-nav"></nav>
 
       <main class="layout-main">
         <aside class="left-nav" aria-label="Left navigation">
           <h2>Navigation</h2>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
-          <div class="nav-item">Left nav item</div>
+          <div id="left-nav-content"></div>
         </aside>
 
         <section class="center-column">
           <div class="panel">
-            <h3>Main Calculation Pane</h3>
-            <p class="placeholder">Placeholder for calculator content.</p>
+            <h3 id="calculator-title">Main Calculation Pane</h3>
+            <p class="placeholder" id="calculator-placeholder">
+              Select a calculator from the navigation list.
+            </p>
           </div>
           <div class="panel">
             <h3>Explanation Pane</h3>
-            <p class="placeholder">Placeholder for explanation content.</p>
+            <p class="placeholder" id="explanation-placeholder">
+              Explanation content will appear here once you choose a calculator.
+            </p>
           </div>
         </section>
 
@@ -58,5 +49,218 @@
         <a href="#">Contact</a>
       </footer>
     </div>
+    <script>
+      const state = {
+        navigation: null,
+        activeCategoryId: null,
+        activeCalculatorId: null,
+      };
+
+      function findCalculatorById(id) {
+        if (!state.navigation) {
+          return null;
+        }
+
+        for (const category of state.navigation.categories) {
+          for (const subcategory of category.subcategories) {
+            const calculator = subcategory.calculators.find(calc => calc.id === id);
+            if (calculator) {
+              return { category, subcategory, calculator };
+            }
+          }
+        }
+
+        return null;
+      }
+
+      function findCalculatorByUrl(path) {
+        if (!state.navigation) {
+          return null;
+        }
+
+        for (const category of state.navigation.categories) {
+          for (const subcategory of category.subcategories) {
+            const calculator = subcategory.calculators.find(calc => calc.url === path);
+            if (calculator) {
+              return { category, subcategory, calculator };
+            }
+          }
+        }
+
+        return null;
+      }
+
+      function getCalculatorFromLocation() {
+        const hashPath = window.location.hash || "";
+        if (hashPath) {
+          const match = findCalculatorByUrl(hashPath);
+          if (match) {
+            return match;
+          }
+        }
+
+        const queryParams = new URLSearchParams(window.location.search);
+        const calculatorId = queryParams.get("calculator");
+        if (calculatorId) {
+          const match = findCalculatorById(calculatorId);
+          if (match) {
+            return match;
+          }
+        }
+
+        return null;
+      }
+
+      function updatePlaceholderContent(calculator) {
+        const title = document.getElementById("calculator-title");
+        const calculatorPlaceholder = document.getElementById("calculator-placeholder");
+        const explanationPlaceholder = document.getElementById("explanation-placeholder");
+
+        if (!calculator) {
+          title.textContent = "Main Calculation Pane";
+          calculatorPlaceholder.textContent = "Select a calculator from the navigation list.";
+          explanationPlaceholder.textContent =
+            "Explanation content will appear here once you choose a calculator.";
+          return;
+        }
+
+        title.textContent = `${calculator.name} Calculator`;
+        calculatorPlaceholder.textContent = `Placeholder content for ${calculator.name}.`;
+        explanationPlaceholder.textContent = `Explanation placeholder for ${calculator.name}.`;
+      }
+
+      function updateUrl(calculator) {
+        if (!calculator || !calculator.url) {
+          return;
+        }
+
+        if (calculator.url.startsWith("#")) {
+          window.location.hash = calculator.url;
+          return;
+        }
+
+        const nextUrl = new URL(window.location.href);
+        nextUrl.searchParams.set("calculator", calculator.id);
+        history.pushState({ calculatorId: calculator.id }, "", nextUrl);
+      }
+
+      function setActiveCalculator(calculator, options = {}) {
+        state.activeCalculatorId = calculator?.id ?? null;
+        updatePlaceholderContent(calculator);
+        highlightActiveCalculator();
+
+        if (!options.skipUrlUpdate && calculator) {
+          updateUrl(calculator);
+        }
+      }
+
+      function highlightActiveCalculator() {
+        const items = document.querySelectorAll(".nav-item");
+        items.forEach(item => {
+          item.classList.toggle("is-active", item.dataset.id === state.activeCalculatorId);
+        });
+      }
+
+      function renderTopNav() {
+        const topNav = document.getElementById("top-nav");
+        topNav.innerHTML = "";
+
+        state.navigation.categories.forEach(category => {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.textContent = category.name;
+          button.classList.toggle("is-active", category.id === state.activeCategoryId);
+          button.addEventListener("click", () => {
+            if (state.activeCategoryId === category.id) {
+              return;
+            }
+            state.activeCategoryId = category.id;
+            renderTopNav();
+            renderLeftNav();
+          });
+          topNav.appendChild(button);
+        });
+      }
+
+      function renderLeftNav() {
+        const container = document.getElementById("left-nav-content");
+        container.innerHTML = "";
+
+        const category = state.navigation.categories.find(
+          item => item.id === state.activeCategoryId
+        );
+        if (!category) {
+          return;
+        }
+
+        category.subcategories.forEach(subcategory => {
+          const subcategoryTitle = document.createElement("h3");
+          subcategoryTitle.textContent = subcategory.name;
+          subcategoryTitle.className = "subcategory-title";
+          container.appendChild(subcategoryTitle);
+
+          subcategory.calculators.forEach(calculator => {
+            const item = document.createElement("button");
+            item.type = "button";
+            item.className = "nav-item";
+            item.textContent = calculator.name;
+            item.dataset.id = calculator.id;
+            item.addEventListener("click", () => {
+              setActiveCalculator(calculator);
+            });
+            container.appendChild(item);
+          });
+        });
+
+        const selectedCalculator = findCalculatorById(state.activeCalculatorId);
+        if (!selectedCalculator || selectedCalculator.category.id !== category.id) {
+          const firstCalculator =
+            category.subcategories[0]?.calculators[0] ?? null;
+          if (firstCalculator) {
+            setActiveCalculator(firstCalculator, { skipUrlUpdate: true });
+          }
+        }
+
+        highlightActiveCalculator();
+      }
+
+      function handleNavigationChange() {
+        const match = getCalculatorFromLocation();
+        if (match) {
+          state.activeCategoryId = match.category.id;
+          renderTopNav();
+          renderLeftNav();
+          setActiveCalculator(match.calculator, { skipUrlUpdate: true });
+        }
+      }
+
+      async function initializeNavigation() {
+        try {
+          const response = await fetch("config/navigation.json");
+          state.navigation = await response.json();
+
+          const initialMatch = getCalculatorFromLocation();
+          if (initialMatch) {
+            state.activeCategoryId = initialMatch.category.id;
+            state.activeCalculatorId = initialMatch.calculator.id;
+          } else {
+            state.activeCategoryId = state.navigation.categories[0]?.id ?? null;
+          }
+
+          renderTopNav();
+          renderLeftNav();
+
+          if (initialMatch) {
+            setActiveCalculator(initialMatch.calculator, { skipUrlUpdate: true });
+          }
+        } catch (error) {
+          console.error("Unable to load navigation.json", error);
+        }
+      }
+
+      window.addEventListener("popstate", handleNavigationChange);
+      window.addEventListener("hashchange", handleNavigationChange);
+      document.addEventListener("DOMContentLoaded", initializeNavigation);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation

- Provide a configuration-driven navigation model so categories, subcategories and calculators are defined in a single schema instead of hard-coded layout HTML.  
- Allow users to select top categories and calculators without reloading the page and to deep-link to calculators via URL.  
- Populate calculator and explanation panes with placeholder content while individual calculators are loaded later.  
- Surface active state in the UI so the selected category and calculator are visually clear.

### Description

- Added a JSON navigation schema at `public/config/navigation.json` that defines `categories`, `subcategories`, and `calculators` with `id`, `name`, and `url` fields.  
- Replaced static nav in `public/index.html` with JS-driven rendering that builds the top nav and left nav from the config and provides routing helpers: `findCalculatorById`, `findCalculatorByUrl`, `getCalculatorFromLocation`, `updateUrl`, and `setActiveCalculator`.  
- Implemented placeholder update logic so the main calculation and explanation panes update immediately when a calculator is selected and the shell does not fully reload.  
- Added styles for active states and subcategory headings in `public/assets/css/layout.css` so selected items use `is-active` styling and nav buttons are keyboard/click friendly.

### Testing

- Started a static server with `python -m http.server 8000` to serve the `public/` directory and verify files are reachable (server started successfully).  
- Attempted an automated end-to-end check using a Playwright script that navigates to the page and clicks `Health` then `Sleep Cycle`, but the Playwright run failed due to the browser process crashing / timing out in this environment.  
- No unit tests or other automated test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69655ce0689c83259ad7a11bf64054e8)