### PR TITLE
Add Math category with calculator tools

### DIFF
--- a/public/calculators/math/basic/explanation.html
+++ b/public/calculators/math/basic/explanation.html
@@ -1,0 +1,12 @@
+<p>
+  This calculator applies the four fundamental operations to two numbers.
+  Add and subtract show the total or difference, while multiply and divide
+  show the product or quotient. Use the Reset button to return to a clean
+  starting point.
+</p>
+<ul>
+  <li><strong>Add:</strong> Combine the two values.</li>
+  <li><strong>Subtract:</strong> Find how much the first value exceeds the second.</li>
+  <li><strong>Multiply:</strong> Scale the first value by the second.</li>
+  <li><strong>Divide:</strong> Split the first value evenly by the second.</li>
+</ul>

--- a/public/calculators/math/basic/index.html
+++ b/public/calculators/math/basic/index.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Basic Calculator | calchowmuch.com</title>
+    <meta
+      name="description"
+      content="Add, subtract, multiply, or divide two numbers instantly."
+    />
+    <link
+      rel="canonical"
+      href="https://calchowmuch.com/calculators/math/basic/"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/base.css" />
+    <link rel="stylesheet" href="/assets/css/ads.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What does the basic calculator do?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "It adds, subtracts, multiplies, or divides two numbers and shows the result instantly."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I divide by zero?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. The calculator warns you when the second value is zero because division by zero is undefined."
+            }
+          }
+        ]
+      }
+    </script>
+    <style>
+      .calculator-page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 24px;
+      }
+
+      .card {
+        background: var(--panel-bg);
+        border-radius: 16px;
+        padding: 24px;
+        box-shadow: var(--panel-shadow);
+        border: 1px solid var(--border-color);
+      }
+
+      .card h1,
+      .card h2 {
+        margin-top: 0;
+      }
+
+      .input-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 16px;
+      }
+
+      label {
+        font-size: 14px;
+        color: var(--muted-text);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      input[type="number"] {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border-color);
+        font-size: 16px;
+      }
+
+      .button-row {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 16px;
+      }
+
+      button {
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: none;
+        background: #2563eb;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+      }
+
+      button.secondary {
+        background: #e2e8f0;
+        color: #1f2937;
+      }
+
+      .result {
+        margin-top: 18px;
+        font-size: 20px;
+        font-weight: 600;
+      }
+
+      .helper {
+        color: var(--muted-text);
+        margin-bottom: 16px;
+      }
+
+      .back-link {
+        display: inline-flex;
+        margin-bottom: 16px;
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="calculator-page">
+      <section class="card" aria-labelledby="calculator-title">
+        <a class="back-link" href="/calculators/index.html">← All calculators</a>
+        <h1 id="calculator-title">Basic Calculator</h1>
+        <p class="helper">Pick an operation to see the result instantly.</p>
+        <div class="input-grid">
+          <div>
+            <label for="basic-value-a">First number</label>
+            <input id="basic-value-a" type="number" value="12" />
+          </div>
+          <div>
+            <label for="basic-value-b">Second number</label>
+            <input id="basic-value-b" type="number" value="8" />
+          </div>
+        </div>
+        <div class="button-row" role="group" aria-label="Operations">
+          <button type="button" data-operation="add">Add</button>
+          <button type="button" data-operation="subtract">Subtract</button>
+          <button type="button" data-operation="multiply">Multiply</button>
+          <button type="button" data-operation="divide">Divide</button>
+        </div>
+        <button class="secondary" type="button" id="basic-reset">Reset</button>
+        <div class="result" id="basic-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" aria-labelledby="explanation-title">
+        <h2 id="explanation-title">Explanation</h2>
+        <div id="basic-explanation">
+          <p>
+            This calculator applies the four fundamental operations to two numbers.
+            Add and subtract show the total or difference, while multiply and divide
+            show the product or quotient. Use the Reset button to return to a clean
+            starting point.
+          </p>
+          <ul>
+            <li><strong>Add:</strong> Combine the two values.</li>
+            <li><strong>Subtract:</strong> Find how much the first value exceeds the second.</li>
+            <li><strong>Multiply:</strong> Scale the first value by the second.</li>
+            <li><strong>Divide:</strong> Split the first value evenly by the second.</li>
+          </ul>
+        </div>
+      </section>
+
+      <aside class="card ad-card" aria-label="Sponsored content">
+        <div class="ad-slot" data-ad-slot="basic-sidebar">
+          Loading ad…
+        </div>
+      </aside>
+    </main>
+
+    <script type="module" src="./module.js"></script>
+    <script async src="/assets/js/ads/loader.js"></script>
+  </body>
+</html>

--- a/public/calculators/math/basic/module.js
+++ b/public/calculators/math/basic/module.js
@@ -1,0 +1,64 @@
+import { add, subtract, multiply, divide } from "/assets/js/core/math.js";
+import { formatNumber } from "/assets/js/core/format.js";
+import { toNumber } from "/assets/js/core/validate.js";
+
+const inputA = document.querySelector("#basic-value-a");
+const inputB = document.querySelector("#basic-value-b");
+const result = document.querySelector("#basic-result");
+const buttons = document.querySelectorAll("[data-operation]");
+const resetButton = document.querySelector("#basic-reset");
+
+const operations = {
+  add: {
+    label: "Sum",
+    fn: add,
+  },
+  subtract: {
+    label: "Difference",
+    fn: subtract,
+  },
+  multiply: {
+    label: "Product",
+    fn: multiply,
+  },
+  divide: {
+    label: "Quotient",
+    fn: divide,
+  },
+};
+
+function updateResult(operationKey) {
+  const a = toNumber(inputA.value);
+  const b = toNumber(inputB.value);
+  const operation = operations[operationKey];
+  const output = operation.fn(a, b);
+
+  if (output === null) {
+    result.textContent = "Result: Division by zero isn't possible.";
+    return;
+  }
+
+  result.textContent = `Result (${operation.label}): ${formatNumber(output, {
+    maximumFractionDigits: 4,
+  })}`;
+}
+
+function bindButtons() {
+  buttons.forEach(button => {
+    button.addEventListener("click", () => {
+      updateResult(button.dataset.operation);
+    });
+  });
+}
+
+function bindReset() {
+  resetButton.addEventListener("click", () => {
+    inputA.value = 0;
+    inputB.value = 0;
+    updateResult("add");
+  });
+}
+
+bindButtons();
+bindReset();
+updateResult("add");

--- a/public/calculators/math/fraction-calculator/explanation.html
+++ b/public/calculators/math/fraction-calculator/explanation.html
@@ -1,0 +1,69 @@
+<h3>Add Fractions</h3>
+<p>
+  To add fractions, find a common denominator (typically the least common multiple),
+  convert both fractions, add the numerators, and simplify.
+</p>
+<p><strong>Example:</strong> 1/4 + 1/8</p>
+<ul>
+  <li>Common denominator: 8</li>
+  <li>Convert: 1/4 = 2/8</li>
+  <li>Add: 2/8 + 1/8 = 3/8</li>
+</ul>
+
+<h3>Subtract Fractions</h3>
+<p>
+  Subtraction works the same as addition, but you subtract the numerators instead.
+</p>
+<p><strong>Example:</strong> 3/4 − 1/6</p>
+<ul>
+  <li>Common denominator: 12</li>
+  <li>Convert: 3/4 = 9/12, 1/6 = 2/12</li>
+  <li>Subtract: 9/12 − 2/12 = 7/12</li>
+</ul>
+
+<h3>Multiply Fractions</h3>
+<p>
+  Multiply the numerators together and the denominators together, then simplify.
+</p>
+<p><strong>Example:</strong> 2/3 × 3/5</p>
+<ul>
+  <li>Multiply numerators: 2 × 3 = 6</li>
+  <li>Multiply denominators: 3 × 5 = 15</li>
+  <li>Result: 6/15 = 2/5 (simplified)</li>
+</ul>
+
+<h3>Divide Fractions</h3>
+<p>
+  To divide fractions, multiply the first fraction by the reciprocal (flipped version) of the second.
+</p>
+<p><strong>Example:</strong> 2/3 ÷ 4/5</p>
+<ul>
+  <li>Reciprocal of 4/5: 5/4</li>
+  <li>Multiply: 2/3 × 5/4 = 10/12 = 5/6 (simplified)</li>
+</ul>
+
+<h3>Simplify Fraction</h3>
+<p>
+  Simplifying a fraction means dividing both numerator and denominator by their greatest common divisor (GCD).
+</p>
+<p><strong>Example:</strong> 6/8</p>
+<ul>
+  <li>GCD of 6 and 8: 2</li>
+  <li>Divide both: 6÷2 = 3, 8÷2 = 4</li>
+  <li>Simplified: 3/4</li>
+</ul>
+
+<h3>Convert Improper ↔ Mixed Number</h3>
+<p>
+  An improper fraction has a numerator larger than the denominator. A mixed number combines a whole number and a fraction.
+</p>
+<p><strong>Example:</strong> 7/3 = 2 1/3</p>
+<ul>
+  <li>Divide: 7 ÷ 3 = 2 remainder 1</li>
+  <li>Whole: 2, Fraction: 1/3</li>
+</ul>
+<p><strong>Reverse example:</strong> 1 2/5 = 7/5</p>
+<ul>
+  <li>Convert: (1 × 5) + 2 = 7</li>
+  <li>Improper: 7/5</li>
+</ul>

--- a/public/calculators/math/fraction-calculator/index.html
+++ b/public/calculators/math/fraction-calculator/index.html
@@ -1,0 +1,441 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Fraction Calculator | calchowmuch.com</title>
+    <meta
+      name="description"
+      content="Add, subtract, multiply, divide, simplify fractions, and convert between improper and mixed numbers."
+    />
+    <link
+      rel="canonical"
+      href="https://calchowmuch.com/calculators/math/fraction-calculator/"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/base.css" />
+    <link rel="stylesheet" href="/assets/css/ads.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do I add fractions?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Enter two fractions in the Add mode. The calculator finds a common denominator, adds the numerators, and simplifies the result."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is a mixed number?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A mixed number combines a whole number and a fraction, like 2 1/3. Use the Convert mode to change between improper fractions and mixed numbers."
+            }
+          }
+        ]
+      }
+    </script>
+    <style>
+      .calculator-page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 24px;
+      }
+
+      .card {
+        background: var(--panel-bg);
+        border-radius: 16px;
+        padding: 24px;
+        box-shadow: var(--panel-shadow);
+        border: 1px solid var(--border-color);
+      }
+
+      .card h1,
+      .card h2 {
+        margin-top: 0;
+      }
+
+      label {
+        font-size: 14px;
+        color: var(--muted-text);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      input[type="number"] {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border-color);
+        font-size: 16px;
+      }
+
+      .mode-selector {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+      }
+
+      .mode-button {
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+        background: var(--panel-bg);
+        color: var(--text-color);
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .mode-button:hover {
+        background: #f1f5f9;
+      }
+
+      .mode-button.active {
+        background: #2563eb;
+        color: #fff;
+        border-color: #2563eb;
+      }
+
+      .input-section {
+        display: none;
+        animation: fadeIn 0.3s;
+      }
+
+      .input-section.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+
+      .fraction-inputs {
+        display: grid;
+        gap: 16px;
+        margin-bottom: 16px;
+        min-height: 180px;
+      }
+
+      .fraction-row {
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        gap: 12px;
+        align-items: center;
+      }
+
+      .fraction-label {
+        font-weight: 600;
+        margin-bottom: 8px;
+      }
+
+      .fraction-divider {
+        text-align: center;
+        font-size: 24px;
+        color: var(--muted-text);
+      }
+
+      .mixed-number-row {
+        display: grid;
+        grid-template-columns: 1fr 2fr;
+        gap: 12px;
+        align-items: end;
+      }
+
+      button.calculate {
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: none;
+        background: #2563eb;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        width: 100%;
+      }
+
+      .result {
+        margin-top: 18px;
+        font-size: 20px;
+        font-weight: 600;
+        min-height: 60px;
+      }
+
+      .result-detail {
+        font-size: 14px;
+        color: var(--muted-text);
+        margin-top: 8px;
+        font-weight: 400;
+      }
+
+      .helper {
+        color: var(--muted-text);
+        margin-bottom: 16px;
+        font-size: 14px;
+      }
+
+      .back-link {
+        display: inline-flex;
+        margin-bottom: 16px;
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="calculator-page">
+      <section class="card" aria-labelledby="calculator-title">
+        <a class="back-link" href="/calculators/index.html">← All calculators</a>
+        <h1 id="calculator-title">Fraction Calculator</h1>
+        <p class="helper">Select a mode to perform different fraction operations.</p>
+
+        <div class="mode-selector" role="tablist" aria-label="Calculation modes">
+          <button class="mode-button active" data-mode="add" role="tab" aria-selected="true">
+            Add
+          </button>
+          <button class="mode-button" data-mode="subtract" role="tab" aria-selected="false">
+            Subtract
+          </button>
+          <button class="mode-button" data-mode="multiply" role="tab" aria-selected="false">
+            Multiply
+          </button>
+          <button class="mode-button" data-mode="divide" role="tab" aria-selected="false">
+            Divide
+          </button>
+          <button class="mode-button" data-mode="simplify" role="tab" aria-selected="false">
+            Simplify
+          </button>
+          <button class="mode-button" data-mode="convert" role="tab" aria-selected="false">
+            Convert
+          </button>
+        </div>
+
+        <!-- Add Fractions -->
+        <div class="input-section active" data-mode="add" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">First fraction</div>
+              <div class="fraction-row">
+                <input id="add-num1" type="number" value="1" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="add-den1" type="number" value="4" placeholder="Denominator" />
+              </div>
+            </div>
+            <div>
+              <div class="fraction-label">Second fraction</div>
+              <div class="fraction-row">
+                <input id="add-num2" type="number" value="1" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="add-den2" type="number" value="8" placeholder="Denominator" />
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="add">Calculate</button>
+        </div>
+
+        <!-- Subtract Fractions -->
+        <div class="input-section" data-mode="subtract" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">First fraction</div>
+              <div class="fraction-row">
+                <input id="sub-num1" type="number" value="3" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="sub-den1" type="number" value="4" placeholder="Denominator" />
+              </div>
+            </div>
+            <div>
+              <div class="fraction-label">Second fraction</div>
+              <div class="fraction-row">
+                <input id="sub-num2" type="number" value="1" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="sub-den2" type="number" value="6" placeholder="Denominator" />
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="subtract">Calculate</button>
+        </div>
+
+        <!-- Multiply Fractions -->
+        <div class="input-section" data-mode="multiply" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">First fraction</div>
+              <div class="fraction-row">
+                <input id="mul-num1" type="number" value="2" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="mul-den1" type="number" value="3" placeholder="Denominator" />
+              </div>
+            </div>
+            <div>
+              <div class="fraction-label">Second fraction</div>
+              <div class="fraction-row">
+                <input id="mul-num2" type="number" value="3" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="mul-den2" type="number" value="5" placeholder="Denominator" />
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="multiply">Calculate</button>
+        </div>
+
+        <!-- Divide Fractions -->
+        <div class="input-section" data-mode="divide" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">First fraction</div>
+              <div class="fraction-row">
+                <input id="div-num1" type="number" value="2" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="div-den1" type="number" value="3" placeholder="Denominator" />
+              </div>
+            </div>
+            <div>
+              <div class="fraction-label">Second fraction</div>
+              <div class="fraction-row">
+                <input id="div-num2" type="number" value="4" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="div-den2" type="number" value="5" placeholder="Denominator" />
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="divide">Calculate</button>
+        </div>
+
+        <!-- Simplify Fraction -->
+        <div class="input-section" data-mode="simplify" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">Fraction to simplify</div>
+              <div class="fraction-row">
+                <input id="simp-num" type="number" value="6" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="simp-den" type="number" value="8" placeholder="Denominator" />
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="simplify">Simplify</button>
+        </div>
+
+        <!-- Convert Improper/Mixed -->
+        <div class="input-section" data-mode="convert" role="tabpanel">
+          <div class="fraction-inputs">
+            <div>
+              <div class="fraction-label">Improper fraction → Mixed number</div>
+              <div class="fraction-row">
+                <input id="conv-imp-num" type="number" value="7" placeholder="Numerator" />
+                <div class="fraction-divider">/</div>
+                <input id="conv-imp-den" type="number" value="3" placeholder="Denominator" />
+              </div>
+            </div>
+            <div>
+              <div class="fraction-label">Mixed number → Improper fraction</div>
+              <div class="mixed-number-row">
+                <input id="conv-mix-whole" type="number" value="1" placeholder="Whole" />
+                <div class="fraction-row">
+                  <input id="conv-mix-num" type="number" value="2" placeholder="Numerator" />
+                  <div class="fraction-divider">/</div>
+                  <input id="conv-mix-den" type="number" value="5" placeholder="Denominator" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="convert">Convert Both</button>
+        </div>
+
+        <div class="result" id="fraction-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" aria-labelledby="explanation-title">
+        <h2 id="explanation-title">Explanation</h2>
+        <div id="fraction-explanation">
+          <h3>Add Fractions</h3>
+          <p>
+            To add fractions, find a common denominator (typically the least common multiple),
+            convert both fractions, add the numerators, and simplify.
+          </p>
+          <p><strong>Example:</strong> 1/4 + 1/8</p>
+          <ul>
+            <li>Common denominator: 8</li>
+            <li>Convert: 1/4 = 2/8</li>
+            <li>Add: 2/8 + 1/8 = 3/8</li>
+          </ul>
+
+          <h3>Subtract Fractions</h3>
+          <p>
+            Subtraction works the same as addition, but you subtract the numerators instead.
+          </p>
+          <p><strong>Example:</strong> 3/4 − 1/6</p>
+          <ul>
+            <li>Common denominator: 12</li>
+            <li>Convert: 3/4 = 9/12, 1/6 = 2/12</li>
+            <li>Subtract: 9/12 − 2/12 = 7/12</li>
+          </ul>
+
+          <h3>Multiply Fractions</h3>
+          <p>
+            Multiply the numerators together and the denominators together, then simplify.
+          </p>
+          <p><strong>Example:</strong> 2/3 × 3/5</p>
+          <ul>
+            <li>Multiply numerators: 2 × 3 = 6</li>
+            <li>Multiply denominators: 3 × 5 = 15</li>
+            <li>Result: 6/15 = 2/5 (simplified)</li>
+          </ul>
+
+          <h3>Divide Fractions</h3>
+          <p>
+            To divide fractions, multiply the first fraction by the reciprocal (flipped version) of the second.
+          </p>
+          <p><strong>Example:</strong> 2/3 ÷ 4/5</p>
+          <ul>
+            <li>Reciprocal of 4/5: 5/4</li>
+            <li>Multiply: 2/3 × 5/4 = 10/12 = 5/6 (simplified)</li>
+          </ul>
+
+          <h3>Simplify Fraction</h3>
+          <p>
+            Simplifying a fraction means dividing both numerator and denominator by their greatest common divisor (GCD).
+          </p>
+          <p><strong>Example:</strong> 6/8</p>
+          <ul>
+            <li>GCD of 6 and 8: 2</li>
+            <li>Divide both: 6÷2 = 3, 8÷2 = 4</li>
+            <li>Simplified: 3/4</li>
+          </ul>
+
+          <h3>Convert Improper ↔ Mixed Number</h3>
+          <p>
+            An improper fraction has a numerator larger than the denominator. A mixed number combines a whole number and a fraction.
+          </p>
+          <p><strong>Example:</strong> 7/3 = 2 1/3</p>
+          <ul>
+            <li>Divide: 7 ÷ 3 = 2 remainder 1</li>
+            <li>Whole: 2, Fraction: 1/3</li>
+          </ul>
+          <p><strong>Reverse example:</strong> 1 2/5 = 7/5</p>
+          <ul>
+            <li>Convert: (1 × 5) + 2 = 7</li>
+            <li>Improper: 7/5</li>
+          </ul>
+        </div>
+      </section>
+
+      <aside class="card ad-card" aria-label="Sponsored content">
+        <div class="ad-slot" data-ad-slot="fraction-calculator-sidebar">
+          Loading ad…
+        </div>
+      </aside>
+    </main>
+
+    <script type="module" src="./module.js"></script>
+    <script async src="/assets/js/ads/loader.js"></script>
+  </body>
+</html>

--- a/public/calculators/math/fraction-calculator/module.js
+++ b/public/calculators/math/fraction-calculator/module.js
@@ -1,0 +1,344 @@
+import { toNumber } from "/assets/js/core/validate.js";
+
+// Fraction math utilities
+function gcd(a, b) {
+  a = Math.abs(a);
+  b = Math.abs(b);
+  while (b !== 0) {
+    const temp = b;
+    b = a % b;
+    a = temp;
+  }
+  return a;
+}
+
+function lcm(a, b) {
+  return Math.abs(a * b) / gcd(a, b);
+}
+
+function simplifyFraction(numerator, denominator) {
+  if (denominator === 0) {
+    return null;
+  }
+  const divisor = gcd(numerator, denominator);
+  return {
+    numerator: numerator / divisor,
+    denominator: denominator / divisor,
+  };
+}
+
+function addFractions(num1, den1, num2, den2) {
+  const commonDen = lcm(den1, den2);
+  const newNum1 = num1 * (commonDen / den1);
+  const newNum2 = num2 * (commonDen / den2);
+  const resultNum = newNum1 + newNum2;
+  return simplifyFraction(resultNum, commonDen);
+}
+
+function subtractFractions(num1, den1, num2, den2) {
+  const commonDen = lcm(den1, den2);
+  const newNum1 = num1 * (commonDen / den1);
+  const newNum2 = num2 * (commonDen / den2);
+  const resultNum = newNum1 - newNum2;
+  return simplifyFraction(resultNum, commonDen);
+}
+
+function multiplyFractions(num1, den1, num2, den2) {
+  const resultNum = num1 * num2;
+  const resultDen = den1 * den2;
+  return simplifyFraction(resultNum, resultDen);
+}
+
+function divideFractions(num1, den1, num2, den2) {
+  if (num2 === 0) {
+    return null;
+  }
+  // Multiply by reciprocal
+  const resultNum = num1 * den2;
+  const resultDen = den1 * num2;
+  return simplifyFraction(resultNum, resultDen);
+}
+
+function improperToMixed(numerator, denominator) {
+  if (denominator === 0) {
+    return null;
+  }
+  const whole = Math.floor(Math.abs(numerator) / Math.abs(denominator));
+  const remainder = Math.abs(numerator) % Math.abs(denominator);
+  const sign = (numerator * denominator < 0) ? -1 : 1;
+
+  return {
+    whole: sign * whole,
+    numerator: remainder,
+    denominator: Math.abs(denominator),
+  };
+}
+
+function mixedToImproper(whole, numerator, denominator) {
+  if (denominator === 0) {
+    return null;
+  }
+  const improperNum = (Math.abs(whole) * denominator) + numerator;
+  const sign = whole < 0 ? -1 : 1;
+  return {
+    numerator: sign * improperNum,
+    denominator: denominator,
+  };
+}
+
+function formatFraction(numerator, denominator) {
+  if (denominator === 1) {
+    return `${numerator}`;
+  }
+  return `${numerator}/${denominator}`;
+}
+
+function formatMixed(whole, numerator, denominator) {
+  if (numerator === 0) {
+    return `${whole}`;
+  }
+  if (whole === 0) {
+    return `${numerator}/${denominator}`;
+  }
+  return `${whole} ${numerator}/${denominator}`;
+}
+
+// Mode switching
+const modeButtons = document.querySelectorAll(".mode-button");
+const inputSections = document.querySelectorAll(".input-section");
+const resultDiv = document.querySelector("#fraction-result");
+
+// Input elements
+const addInputs = {
+  num1: document.querySelector("#add-num1"),
+  den1: document.querySelector("#add-den1"),
+  num2: document.querySelector("#add-num2"),
+  den2: document.querySelector("#add-den2"),
+};
+
+const subInputs = {
+  num1: document.querySelector("#sub-num1"),
+  den1: document.querySelector("#sub-den1"),
+  num2: document.querySelector("#sub-num2"),
+  den2: document.querySelector("#sub-den2"),
+};
+
+const mulInputs = {
+  num1: document.querySelector("#mul-num1"),
+  den1: document.querySelector("#mul-den1"),
+  num2: document.querySelector("#mul-num2"),
+  den2: document.querySelector("#mul-den2"),
+};
+
+const divInputs = {
+  num1: document.querySelector("#div-num1"),
+  den1: document.querySelector("#div-den1"),
+  num2: document.querySelector("#div-num2"),
+  den2: document.querySelector("#div-den2"),
+};
+
+const simpInputs = {
+  num: document.querySelector("#simp-num"),
+  den: document.querySelector("#simp-den"),
+};
+
+const convInputs = {
+  impNum: document.querySelector("#conv-imp-num"),
+  impDen: document.querySelector("#conv-imp-den"),
+  mixWhole: document.querySelector("#conv-mix-whole"),
+  mixNum: document.querySelector("#conv-mix-num"),
+  mixDen: document.querySelector("#conv-mix-den"),
+};
+
+// Calculate buttons
+const calculateButtons = document.querySelectorAll(".calculate");
+
+// Mode switching functionality
+function switchMode(mode) {
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === mode;
+    btn.classList.toggle("active", isActive);
+    btn.setAttribute("aria-selected", isActive);
+  });
+
+  inputSections.forEach(section => {
+    section.classList.toggle("active", section.dataset.mode === mode);
+  });
+
+  resultDiv.innerHTML = "";
+}
+
+// Calculation functions
+function calculateAdd() {
+  const num1 = toNumber(addInputs.num1.value);
+  const den1 = toNumber(addInputs.den1.value);
+  const num2 = toNumber(addInputs.num2.value);
+  const den2 = toNumber(addInputs.den2.value);
+
+  if (den1 === 0 || den2 === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+    return;
+  }
+
+  const result = addFractions(num1, den1, num2, den2);
+  const mixed = improperToMixed(result.numerator, result.denominator);
+
+  resultDiv.innerHTML = `
+    <div>${formatFraction(num1, den1)} + ${formatFraction(num2, den2)} = ${formatFraction(result.numerator, result.denominator)}</div>
+    ${Math.abs(result.numerator) > result.denominator ? `<div class="result-detail">Mixed form: ${formatMixed(mixed.whole, mixed.numerator, mixed.denominator)}</div>` : ''}
+  `;
+}
+
+function calculateSubtract() {
+  const num1 = toNumber(subInputs.num1.value);
+  const den1 = toNumber(subInputs.den1.value);
+  const num2 = toNumber(subInputs.num2.value);
+  const den2 = toNumber(subInputs.den2.value);
+
+  if (den1 === 0 || den2 === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+    return;
+  }
+
+  const result = subtractFractions(num1, den1, num2, den2);
+  const mixed = improperToMixed(result.numerator, result.denominator);
+
+  resultDiv.innerHTML = `
+    <div>${formatFraction(num1, den1)} − ${formatFraction(num2, den2)} = ${formatFraction(result.numerator, result.denominator)}</div>
+    ${Math.abs(result.numerator) > result.denominator ? `<div class="result-detail">Mixed form: ${formatMixed(mixed.whole, mixed.numerator, mixed.denominator)}</div>` : ''}
+  `;
+}
+
+function calculateMultiply() {
+  const num1 = toNumber(mulInputs.num1.value);
+  const den1 = toNumber(mulInputs.den1.value);
+  const num2 = toNumber(mulInputs.num2.value);
+  const den2 = toNumber(mulInputs.den2.value);
+
+  if (den1 === 0 || den2 === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+    return;
+  }
+
+  const result = multiplyFractions(num1, den1, num2, den2);
+  const mixed = improperToMixed(result.numerator, result.denominator);
+
+  resultDiv.innerHTML = `
+    <div>${formatFraction(num1, den1)} × ${formatFraction(num2, den2)} = ${formatFraction(result.numerator, result.denominator)}</div>
+    ${Math.abs(result.numerator) > result.denominator ? `<div class="result-detail">Mixed form: ${formatMixed(mixed.whole, mixed.numerator, mixed.denominator)}</div>` : ''}
+  `;
+}
+
+function calculateDivide() {
+  const num1 = toNumber(divInputs.num1.value);
+  const den1 = toNumber(divInputs.den1.value);
+  const num2 = toNumber(divInputs.num2.value);
+  const den2 = toNumber(divInputs.den2.value);
+
+  if (den1 === 0 || den2 === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+    return;
+  }
+
+  const result = divideFractions(num1, den1, num2, den2);
+  if (result === null) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot divide by zero.</div>`;
+    return;
+  }
+
+  const mixed = improperToMixed(result.numerator, result.denominator);
+
+  resultDiv.innerHTML = `
+    <div>${formatFraction(num1, den1)} ÷ ${formatFraction(num2, den2)} = ${formatFraction(result.numerator, result.denominator)}</div>
+    ${Math.abs(result.numerator) > result.denominator ? `<div class="result-detail">Mixed form: ${formatMixed(mixed.whole, mixed.numerator, mixed.denominator)}</div>` : ''}
+  `;
+}
+
+function calculateSimplify() {
+  const num = toNumber(simpInputs.num.value);
+  const den = toNumber(simpInputs.den.value);
+
+  if (den === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+    return;
+  }
+
+  const result = simplifyFraction(num, den);
+  const divisor = gcd(num, den);
+
+  resultDiv.innerHTML = `
+    <div>${formatFraction(num, den)} = ${formatFraction(result.numerator, result.denominator)}</div>
+    <div class="result-detail">GCD: ${divisor}</div>
+  `;
+}
+
+function calculateConvert() {
+  // Convert improper to mixed
+  const impNum = toNumber(convInputs.impNum.value);
+  const impDen = toNumber(convInputs.impDen.value);
+
+  // Convert mixed to improper
+  const mixWhole = toNumber(convInputs.mixWhole.value);
+  const mixNum = toNumber(convInputs.mixNum.value);
+  const mixDen = toNumber(convInputs.mixDen.value);
+
+  let output = "";
+
+  if (impDen !== 0) {
+    const mixed = improperToMixed(impNum, impDen);
+    if (mixed) {
+      output += `<div>${formatFraction(impNum, impDen)} = ${formatMixed(mixed.whole, mixed.numerator, mixed.denominator)}</div>`;
+    }
+  }
+
+  if (mixDen !== 0) {
+    const improper = mixedToImproper(mixWhole, mixNum, mixDen);
+    if (improper) {
+      if (output) output += `<div style="margin-top: 12px;"></div>`;
+      output += `<div>${formatMixed(mixWhole, mixNum, mixDen)} = ${formatFraction(improper.numerator, improper.denominator)}</div>`;
+    }
+  }
+
+  if (!output) {
+    output = `<div style="color: #dc2626;">Cannot calculate: denominator cannot be zero.</div>`;
+  }
+
+  resultDiv.innerHTML = output;
+}
+
+// Event listeners for mode buttons
+modeButtons.forEach(btn => {
+  btn.addEventListener("click", () => {
+    switchMode(btn.dataset.mode);
+  });
+});
+
+// Event listeners for calculate buttons
+calculateButtons.forEach(btn => {
+  btn.addEventListener("click", () => {
+    const mode = btn.dataset.calculate;
+    switch (mode) {
+      case "add":
+        calculateAdd();
+        break;
+      case "subtract":
+        calculateSubtract();
+        break;
+      case "multiply":
+        calculateMultiply();
+        break;
+      case "divide":
+        calculateDivide();
+        break;
+      case "simplify":
+        calculateSimplify();
+        break;
+      case "convert":
+        calculateConvert();
+        break;
+    }
+  });
+});
+
+// Initialize with first calculation
+calculateAdd();

--- a/public/calculators/math/percentage-calculator/explanation.html
+++ b/public/calculators/math/percentage-calculator/explanation.html
@@ -1,0 +1,45 @@
+<h3>Percentage Increase</h3>
+<p>
+  Percentage increase shows how much a value has grown relative to its original amount.
+  It's calculated by finding the difference between new and original, dividing by the original,
+  and multiplying by 100.
+</p>
+<p><strong>Example:</strong> 80 → 100</p>
+<ul>
+  <li>Increase amount: 100 - 80 = 20</li>
+  <li>Percentage increase: (20 ÷ 80) × 100 = 25%</li>
+</ul>
+
+<h3>Percentage Decrease</h3>
+<p>
+  Percentage decrease measures how much a value has fallen relative to where it started.
+  The calculation is the same as increase, but the result is negative (or shown as a decrease).
+</p>
+<p><strong>Example:</strong> 100 → 75</p>
+<ul>
+  <li>Decrease amount: 100 - 75 = 25</li>
+  <li>Percentage decrease: (25 ÷ 100) × 100 = 25%</li>
+</ul>
+
+<h3>What % of what</h3>
+<p>
+  This mode finds what percentage one number (the part) is of another number (the whole).
+  Divide the part by the whole and multiply by 100.
+</p>
+<p><strong>Example:</strong> 25 is what % of 200?</p>
+<ul>
+  <li>Calculation: (25 ÷ 200) × 100 = 12.5%</li>
+</ul>
+<p class="helper">
+  <strong>Note:</strong> If the whole value is 0, the calculation is undefined (cannot divide by zero).
+</p>
+
+<h3>What is X% of Y</h3>
+<p>
+  This mode calculates a specific percentage of a given value. Multiply the base value
+  by the percentage and divide by 100.
+</p>
+<p><strong>Example:</strong> What is 15% of 80?</p>
+<ul>
+  <li>Calculation: (15 ÷ 100) × 80 = 12</li>
+</ul>

--- a/public/calculators/math/percentage-calculator/index.html
+++ b/public/calculators/math/percentage-calculator/index.html
@@ -1,0 +1,313 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Percentage Calculator | calchowmuch.com</title>
+    <meta
+      name="description"
+      content="Calculate percentage increase, decrease, and more with multiple percentage operations in one tool."
+    />
+    <link
+      rel="canonical"
+      href="https://calchowmuch.com/calculators/math/percentage-calculator/"
+    />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/assets/css/base.css" />
+    <link rel="stylesheet" href="/assets/css/ads.css" />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "How do I calculate percentage increase?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Enter the original value and new value. The calculator shows the increase amount and percentage increase relative to the original."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What happens when the whole value is zero?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Division by zero is undefined, so the calculator will show a warning when the whole value is zero in 'What % of what' mode."
+            }
+          }
+        ]
+      }
+    </script>
+    <style>
+      .calculator-page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 24px;
+      }
+
+      .card {
+        background: var(--panel-bg);
+        border-radius: 16px;
+        padding: 24px;
+        box-shadow: var(--panel-shadow);
+        border: 1px solid var(--border-color);
+      }
+
+      .card h1,
+      .card h2 {
+        margin-top: 0;
+      }
+
+      label {
+        font-size: 14px;
+        color: var(--muted-text);
+        display: block;
+        margin-bottom: 6px;
+      }
+
+      input[type="number"] {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: 1px solid var(--border-color);
+        font-size: 16px;
+      }
+
+      .mode-selector {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+      }
+
+      .mode-button {
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid var(--border-color);
+        background: var(--panel-bg);
+        color: var(--text-color);
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+      }
+
+      .mode-button:hover {
+        background: #f1f5f9;
+      }
+
+      .mode-button.active {
+        background: #2563eb;
+        color: #fff;
+        border-color: #2563eb;
+      }
+
+      .input-section {
+        display: none;
+        animation: fadeIn 0.3s;
+      }
+
+      .input-section.active {
+        display: block;
+      }
+
+      @keyframes fadeIn {
+        from { opacity: 0; }
+        to { opacity: 1; }
+      }
+
+      .input-stack {
+        display: grid;
+        gap: 16px;
+        margin-bottom: 16px;
+        min-height: 160px;
+      }
+
+      button.calculate {
+        padding: 10px 12px;
+        border-radius: 10px;
+        border: none;
+        background: #2563eb;
+        color: #fff;
+        font-weight: 600;
+        cursor: pointer;
+        width: 100%;
+      }
+
+      .result {
+        margin-top: 18px;
+        font-size: 18px;
+        font-weight: 600;
+        min-height: 60px;
+      }
+
+      .result-detail {
+        font-size: 14px;
+        color: var(--muted-text);
+        margin-top: 8px;
+        font-weight: 400;
+      }
+
+      .helper {
+        color: var(--muted-text);
+        margin-bottom: 16px;
+        font-size: 14px;
+      }
+
+      .back-link {
+        display: inline-flex;
+        margin-bottom: 16px;
+        color: #2563eb;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="calculator-page">
+      <section class="card" aria-labelledby="calculator-title">
+        <a class="back-link" href="/calculators/index.html">← All calculators</a>
+        <h1 id="calculator-title">Percentage Calculator</h1>
+        <p class="helper">Select a mode to perform different percentage calculations.</p>
+
+        <div class="mode-selector" role="tablist" aria-label="Calculation modes">
+          <button class="mode-button active" data-mode="increase" role="tab" aria-selected="true">
+            Percentage Increase
+          </button>
+          <button class="mode-button" data-mode="decrease" role="tab" aria-selected="false">
+            Percentage Decrease
+          </button>
+          <button class="mode-button" data-mode="what-percent" role="tab" aria-selected="false">
+            What % of what
+          </button>
+          <button class="mode-button" data-mode="percent-of" role="tab" aria-selected="false">
+            What is X% of Y
+          </button>
+        </div>
+
+        <!-- Percentage Increase -->
+        <div class="input-section active" data-mode="increase" role="tabpanel">
+          <div class="input-stack">
+            <div>
+              <label for="increase-original">Original value</label>
+              <input id="increase-original" type="number" value="80" step="any" />
+            </div>
+            <div>
+              <label for="increase-new">New value</label>
+              <input id="increase-new" type="number" value="100" step="any" />
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="increase">Calculate</button>
+        </div>
+
+        <!-- Percentage Decrease -->
+        <div class="input-section" data-mode="decrease" role="tabpanel">
+          <div class="input-stack">
+            <div>
+              <label for="decrease-original">Original value</label>
+              <input id="decrease-original" type="number" value="100" step="any" />
+            </div>
+            <div>
+              <label for="decrease-new">New value</label>
+              <input id="decrease-new" type="number" value="75" step="any" />
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="decrease">Calculate</button>
+        </div>
+
+        <!-- What % of what -->
+        <div class="input-section" data-mode="what-percent" role="tabpanel">
+          <div class="input-stack">
+            <div>
+              <label for="what-percent-part">Part value</label>
+              <input id="what-percent-part" type="number" value="25" step="any" />
+            </div>
+            <div>
+              <label for="what-percent-whole">Whole value</label>
+              <input id="what-percent-whole" type="number" value="200" step="any" />
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="what-percent">Calculate</button>
+        </div>
+
+        <!-- What is X% of Y -->
+        <div class="input-section" data-mode="percent-of" role="tabpanel">
+          <div class="input-stack">
+            <div>
+              <label for="percent-of-percent">Percentage (%)</label>
+              <input id="percent-of-percent" type="number" value="15" step="any" />
+            </div>
+            <div>
+              <label for="percent-of-base">Base value</label>
+              <input id="percent-of-base" type="number" value="80" step="any" />
+            </div>
+          </div>
+          <button type="button" class="calculate" data-calculate="percent-of">Calculate</button>
+        </div>
+
+        <div class="result" id="percentage-result" aria-live="polite"></div>
+      </section>
+
+      <section class="card" aria-labelledby="explanation-title">
+        <h2 id="explanation-title">Explanation</h2>
+        <div id="percentage-explanation">
+          <h3>Percentage Increase</h3>
+          <p>
+            Percentage increase shows how much a value has grown relative to its original amount.
+            It's calculated by finding the difference between new and original, dividing by the original,
+            and multiplying by 100.
+          </p>
+          <p><strong>Example:</strong> 80 → 100</p>
+          <ul>
+            <li>Increase amount: 100 - 80 = 20</li>
+            <li>Percentage increase: (20 ÷ 80) × 100 = 25%</li>
+          </ul>
+
+          <h3>Percentage Decrease</h3>
+          <p>
+            Percentage decrease measures how much a value has fallen relative to where it started.
+            The calculation is the same as increase, but the result is negative (or shown as a decrease).
+          </p>
+          <p><strong>Example:</strong> 100 → 75</p>
+          <ul>
+            <li>Decrease amount: 100 - 75 = 25</li>
+            <li>Percentage decrease: (25 ÷ 100) × 100 = 25%</li>
+          </ul>
+
+          <h3>What % of what</h3>
+          <p>
+            This mode finds what percentage one number (the part) is of another number (the whole).
+            Divide the part by the whole and multiply by 100.
+          </p>
+          <p><strong>Example:</strong> 25 is what % of 200?</p>
+          <ul>
+            <li>Calculation: (25 ÷ 200) × 100 = 12.5%</li>
+          </ul>
+          <p class="helper">
+            <strong>Note:</strong> If the whole value is 0, the calculation is undefined (cannot divide by zero).
+          </p>
+
+          <h3>What is X% of Y</h3>
+          <p>
+            This mode calculates a specific percentage of a given value. Multiply the base value
+            by the percentage and divide by 100.
+          </p>
+          <p><strong>Example:</strong> What is 15% of 80?</p>
+          <ul>
+            <li>Calculation: (15 ÷ 100) × 80 = 12</li>
+          </ul>
+        </div>
+      </section>
+
+      <aside class="card ad-card" aria-label="Sponsored content">
+        <div class="ad-slot" data-ad-slot="percentage-calculator-sidebar">
+          Loading ad…
+        </div>
+      </aside>
+    </main>
+
+    <script type="module" src="./module.js"></script>
+    <script async src="/assets/js/ads/loader.js"></script>
+  </body>
+</html>

--- a/public/calculators/math/percentage-calculator/module.js
+++ b/public/calculators/math/percentage-calculator/module.js
@@ -1,0 +1,144 @@
+import { formatNumber } from "/assets/js/core/format.js";
+import { toNumber } from "/assets/js/core/validate.js";
+
+// Mode switching
+const modeButtons = document.querySelectorAll(".mode-button");
+const inputSections = document.querySelectorAll(".input-section");
+const resultDiv = document.querySelector("#percentage-result");
+
+// Input elements for each mode
+const increaseInputs = {
+  original: document.querySelector("#increase-original"),
+  new: document.querySelector("#increase-new"),
+};
+
+const decreaseInputs = {
+  original: document.querySelector("#decrease-original"),
+  new: document.querySelector("#decrease-new"),
+};
+
+const whatPercentInputs = {
+  part: document.querySelector("#what-percent-part"),
+  whole: document.querySelector("#what-percent-whole"),
+};
+
+const percentOfInputs = {
+  percent: document.querySelector("#percent-of-percent"),
+  base: document.querySelector("#percent-of-base"),
+};
+
+// Calculate buttons
+const calculateButtons = document.querySelectorAll(".calculate");
+
+// Mode switching functionality
+function switchMode(mode) {
+  // Update button states
+  modeButtons.forEach(btn => {
+    const isActive = btn.dataset.mode === mode;
+    btn.classList.toggle("active", isActive);
+    btn.setAttribute("aria-selected", isActive);
+  });
+
+  // Update input section visibility
+  inputSections.forEach(section => {
+    section.classList.toggle("active", section.dataset.mode === mode);
+  });
+
+  // Clear result
+  resultDiv.innerHTML = "";
+}
+
+// Calculation functions
+function calculateIncrease() {
+  const original = toNumber(increaseInputs.original.value);
+  const newValue = toNumber(increaseInputs.new.value);
+
+  if (original === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: original value is zero.</div>`;
+    return;
+  }
+
+  const increaseAmount = newValue - original;
+  const percentIncrease = (increaseAmount / original) * 100;
+
+  resultDiv.innerHTML = `
+    <div>Increase: ${formatNumber(increaseAmount, { maximumFractionDigits: 2 })}</div>
+    <div class="result-detail">Percentage increase: ${formatNumber(percentIncrease, { maximumFractionDigits: 2 })}%</div>
+  `;
+}
+
+function calculateDecrease() {
+  const original = toNumber(decreaseInputs.original.value);
+  const newValue = toNumber(decreaseInputs.new.value);
+
+  if (original === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: original value is zero.</div>`;
+    return;
+  }
+
+  const decreaseAmount = original - newValue;
+  const percentDecrease = (decreaseAmount / original) * 100;
+
+  resultDiv.innerHTML = `
+    <div>Decrease: ${formatNumber(decreaseAmount, { maximumFractionDigits: 2 })}</div>
+    <div class="result-detail">Percentage decrease: ${formatNumber(percentDecrease, { maximumFractionDigits: 2 })}%</div>
+  `;
+}
+
+function calculateWhatPercent() {
+  const part = toNumber(whatPercentInputs.part.value);
+  const whole = toNumber(whatPercentInputs.whole.value);
+
+  if (whole === 0) {
+    resultDiv.innerHTML = `<div style="color: #dc2626;">Cannot calculate: whole value is zero (division by zero).</div>`;
+    return;
+  }
+
+  const percent = (part / whole) * 100;
+
+  resultDiv.innerHTML = `
+    <div>${formatNumber(part, { maximumFractionDigits: 2 })} is ${formatNumber(percent, { maximumFractionDigits: 2 })}% of ${formatNumber(whole, { maximumFractionDigits: 2 })}</div>
+  `;
+}
+
+function calculatePercentOf() {
+  const percent = toNumber(percentOfInputs.percent.value);
+  const base = toNumber(percentOfInputs.base.value);
+
+  const result = (percent / 100) * base;
+
+  resultDiv.innerHTML = `
+    <div>${formatNumber(percent, { maximumFractionDigits: 2 })}% of ${formatNumber(base, { maximumFractionDigits: 2 })} = ${formatNumber(result, { maximumFractionDigits: 2 })}</div>
+  `;
+}
+
+// Event listeners for mode buttons
+modeButtons.forEach(btn => {
+  btn.addEventListener("click", () => {
+    switchMode(btn.dataset.mode);
+  });
+});
+
+// Event listeners for calculate buttons
+calculateButtons.forEach(btn => {
+  btn.addEventListener("click", () => {
+    const mode = btn.dataset.calculate;
+    switch (mode) {
+      case "increase":
+        calculateIncrease();
+        break;
+      case "decrease":
+        calculateDecrease();
+        break;
+      case "what-percent":
+        calculateWhatPercent();
+        break;
+      case "percent-of":
+        calculatePercentOf();
+        break;
+    }
+  });
+});
+
+// Initialize with first calculation
+calculateIncrease();

--- a/public/config/navigation.json
+++ b/public/config/navigation.json
@@ -1,6 +1,33 @@
 {
   "categories": [
     {
+      "id": "math",
+      "name": "Math",
+      "subcategories": [
+        {
+          "id": "simple",
+          "name": "Simple",
+          "calculators": [
+            {
+              "id": "basic",
+              "name": "Basic",
+              "url": "#/calculators/basic"
+            },
+            {
+              "id": "percentage-calculator",
+              "name": "Percentage Calculator",
+              "url": "#/calculators/percentage-calculator"
+            },
+            {
+              "id": "fraction-calculator",
+              "name": "Fraction Calculator",
+              "url": "#/calculators/fraction-calculator"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "id": "finance",
       "name": "Finance",
       "subcategories": [


### PR DESCRIPTION
This commit adds a new Math category to the top navigation with a Simple subcategory containing three calculators: Basic, Percentage Calculator, and Fraction Calculator.

Changes:
- Updated navigation.json to add Math category as the first category
- Created Basic Calculator with add, subtract, multiply, divide operations
- Created Percentage Calculator with 4 modes:
  * Percentage Increase
  * Percentage Decrease
  * What % of what
  * What is X% of Y
- Created Fraction Calculator with 6 operations:
  * Add fractions
  * Subtract fractions
  * Multiply fractions
  * Divide fractions
  * Simplify fraction
  * Convert improper ↔ mixed number

All calculators include:
- Full standalone HTML pages with SEO metadata
- Interactive JavaScript modules with calculation logic
- Static explanation content with worked examples
- Support for deep linking via hash URLs
- Proper error handling (division by zero, etc.)
- Responsive layouts matching existing calculator design

The Percentage and Fraction calculators use a single-page, multi-mode approach with tab-based mode selectors that change inputs dynamically without page reloads or layout shifts.