### PR TITLE
Fix calculator links and loader paths

### DIFF
--- a/public/calculators/index.html
+++ b/public/calculators/index.html
@@ -69,8 +69,8 @@
         <h2 id="math-title">Math</h2>
         <div class="calculator-grid">
           <div class="calculator-card">
-            <a href="/calculators/math/basic-operations/index.html">
-              Basic Operations
+            <a href="/calculators/math/basic/index.html">
+              Basic Calculator
             </a>
             <p>Add, subtract, multiply, or divide two numbers.</p>
           </div>

--- a/public/index.html
+++ b/public/index.html
@@ -119,7 +119,9 @@
         const pathMap = {
           'basic': '/calculators/math/basic',
           'percentage-calculator': '/calculators/math/percentage-calculator',
+          'percentage-increase': '/calculators/math/percentage-increase',
           'fraction-calculator': '/calculators/math/fraction-calculator',
+          'credit-card-payoff': '/calculators/finance/credit-card-payoff',
         };
         return pathMap[calculatorId] || null;
       }

--- a/public/seo/structured-data.json
+++ b/public/seo/structured-data.json
@@ -1,8 +1,8 @@
 {
   "calculators": [
     {
-      "id": "basic-operations",
-      "url": "https://calchowmuch.com/calculators/math/basic-operations/",
+      "id": "basic",
+      "url": "https://calchowmuch.com/calculators/math/basic/",
       "structuredData": {
         "@context": "https://schema.org",
         "@type": "FAQPage",


### PR DESCRIPTION
### Motivation

- Remove references to the deleted `basic-operations` page and ensure navigation and SEO point to the new basic calculator path.  
- Prevent the shell loader from returning a null path for newly advertised calculators by adding the missing mappings so the calculators load instead of showing an error.

### Description

- Update the calculators landing page link and label from `/calculators/math/basic-operations/` to `/calculators/math/basic/` in `public/calculators/index.html`.  
- Replace the `basic-operations` entry with `basic` and update its `url` in `public/seo/structured-data.json` to avoid structured data pointing at a removed page.  
- Add path mappings for `percentage-increase` and `credit-card-payoff` in `getCalculatorPath` inside `public/index.html` so the loader can resolve those calculator IDs.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966b441059c8325ac728bad6e602c72)