### PR TITLE
Standardize calculator input/button sizing and add multi-input support to Basic calculator

### DIFF
--- a/public/assets/css/calculator.css
+++ b/public/assets/css/calculator.css
@@ -1,0 +1,140 @@
+:root {
+  --calculator-input-padding: 10px 12px;
+  --calculator-input-radius: 10px;
+  --calculator-button-padding: 10px 12px;
+  --calculator-button-radius: 10px;
+}
+
+.calculator-ui label {
+  font-size: 14px;
+  color: var(--muted-text);
+  display: block;
+  margin-bottom: 6px;
+}
+
+.calculator-ui input[type="number"] {
+  width: 100%;
+  padding: var(--calculator-input-padding);
+  border-radius: var(--calculator-input-radius);
+  border: 1px solid var(--border-color);
+  font-size: 16px;
+}
+
+.calculator-ui .helper {
+  color: var(--muted-text);
+  margin-bottom: 16px;
+  font-size: 14px;
+}
+
+.calculator-ui .input-stack {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.calculator-ui .calculator-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.calculator-ui .toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.calculator-ui .button-row {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.calculator-ui .calculator-button {
+  padding: var(--calculator-button-padding);
+  border-radius: var(--calculator-button-radius);
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.calculator-ui .calculator-button.secondary {
+  background: #e2e8f0;
+  color: #1f2937;
+}
+
+.calculator-ui .calculator-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.calculator-ui .result {
+  margin-top: 18px;
+  font-size: 18px;
+  font-weight: 600;
+  min-height: 60px;
+}
+
+.calculator-ui .result-detail {
+  font-size: 14px;
+  color: var(--muted-text);
+  margin-top: 8px;
+  font-weight: 400;
+}
+
+.calculator-ui .mode-selector {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.calculator-ui .mode-button {
+  padding: 8px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  background: var(--panel-bg);
+  color: #1f2937;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.calculator-ui .mode-button:hover {
+  background: #f1f5f9;
+}
+
+.calculator-ui .mode-button.active {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.calculator-ui .input-section {
+  display: none;
+  animation: calculatorFadeIn 0.3s;
+}
+
+.calculator-ui .input-section.active {
+  display: block;
+}
+
+@keyframes calculatorFadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.calculator-ui .calculate {
+  width: 100%;
+}

--- a/public/calculators/math/basic/index.html
+++ b/public/calculators/math/basic/index.html
@@ -1,77 +1,29 @@
-<p class="helper">Pick an operation to see the result instantly.</p>
-<div class="input-grid">
-  <div>
-    <label for="basic-value-a">First number</label>
-    <input id="basic-value-a" type="number" value="12" />
+<div class="calculator-ui">
+  <p class="helper">Pick an operation to see the result instantly.</p>
+  <div class="calculator-toolbar">
+    <button class="calculator-button secondary" type="button" id="basic-reset">Reset</button>
+    <div class="toolbar-actions">
+      <button class="calculator-button secondary" type="button" id="basic-add-input">Add number</button>
+      <button class="calculator-button secondary" type="button" id="basic-remove-input">
+        Remove number
+      </button>
+    </div>
   </div>
-  <div>
-    <label for="basic-value-b">Second number</label>
-    <input id="basic-value-b" type="number" value="8" />
+  <div class="input-stack" id="basic-inputs">
+    <div class="input-row">
+      <label for="basic-value-1">Number 1</label>
+      <input id="basic-value-1" type="number" value="12" data-basic-input="true" />
+    </div>
+    <div class="input-row">
+      <label for="basic-value-2">Number 2</label>
+      <input id="basic-value-2" type="number" value="8" data-basic-input="true" />
+    </div>
   </div>
+  <div class="button-row" role="group" aria-label="Operations">
+    <button class="calculator-button" type="button" data-operation="add">Add</button>
+    <button class="calculator-button" type="button" data-operation="subtract">Subtract</button>
+    <button class="calculator-button" type="button" data-operation="multiply">Multiply</button>
+    <button class="calculator-button" type="button" data-operation="divide">Divide</button>
+  </div>
+  <div class="result" id="basic-result" aria-live="polite"></div>
 </div>
-<div class="button-row" role="group" aria-label="Operations">
-  <button type="button" data-operation="add">Add</button>
-  <button type="button" data-operation="subtract">Subtract</button>
-  <button type="button" data-operation="multiply">Multiply</button>
-  <button type="button" data-operation="divide">Divide</button>
-</div>
-<button class="secondary" type="button" id="basic-reset">Reset</button>
-<div class="result" id="basic-result" aria-live="polite"></div>
-
-<style>
-  .input-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-    gap: 16px;
-    margin-bottom: 16px;
-  }
-
-  label {
-    font-size: 14px;
-    color: var(--muted-text);
-    display: block;
-    margin-bottom: 6px;
-  }
-
-  input[type="number"] {
-    width: 100%;
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px solid var(--border-color);
-    font-size: 16px;
-  }
-
-  .button-row {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 12px;
-    margin-top: 16px;
-  }
-
-  button {
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: none;
-    background: #2563eb;
-    color: #fff;
-    font-weight: 600;
-    cursor: pointer;
-  }
-
-  button.secondary {
-    background: #e2e8f0;
-    color: #1f2937;
-    margin-top: 12px;
-  }
-
-  .result {
-    margin-top: 18px;
-    font-size: 20px;
-    font-weight: 600;
-  }
-
-  .helper {
-    color: var(--muted-text);
-    margin-bottom: 16px;
-  }
-</style>

--- a/public/calculators/math/basic/module.js
+++ b/public/calculators/math/basic/module.js
@@ -2,11 +2,15 @@ import { add, subtract, multiply, divide } from "/assets/js/core/math.js";
 import { formatNumber } from "/assets/js/core/format.js";
 import { toNumber } from "/assets/js/core/validate.js";
 
-const inputA = document.querySelector("#basic-value-a");
-const inputB = document.querySelector("#basic-value-b");
+const inputContainer = document.querySelector("#basic-inputs");
 const result = document.querySelector("#basic-result");
 const buttons = document.querySelectorAll("[data-operation]");
 const resetButton = document.querySelector("#basic-reset");
+const addInputButton = document.querySelector("#basic-add-input");
+const removeInputButton = document.querySelector("#basic-remove-input");
+
+const defaultValues = [12, 8];
+let activeOperation = "add";
 
 const operations = {
   add: {
@@ -27,11 +31,45 @@ const operations = {
   },
 };
 
+function getInputValues() {
+  return Array.from(inputContainer.querySelectorAll("[data-basic-input]")).map(input =>
+    toNumber(input.value),
+  );
+}
+
+function calculateMultiple(operationKey, values) {
+  if (!values.length) {
+    return 0;
+  }
+
+  if (operationKey === "add") {
+    return values.reduce((total, value) => add(total, value), 0);
+  }
+
+  if (operationKey === "multiply") {
+    return values.reduce((total, value) => multiply(total, value), 1);
+  }
+
+  let runningTotal = values[0];
+  for (let index = 1; index < values.length; index += 1) {
+    const nextValue = values[index];
+    const operationFn = operations[operationKey].fn;
+    const output = operationFn(runningTotal, nextValue);
+
+    if (output === null) {
+      return null;
+    }
+
+    runningTotal = output;
+  }
+
+  return runningTotal;
+}
+
 function updateResult(operationKey) {
-  const a = toNumber(inputA.value);
-  const b = toNumber(inputB.value);
   const operation = operations[operationKey];
-  const output = operation.fn(a, b);
+  const values = getInputValues();
+  const output = calculateMultiple(operationKey, values);
 
   if (output === null) {
     result.textContent = "Result: Division by zero isn't possible.";
@@ -46,19 +84,75 @@ function updateResult(operationKey) {
 function bindButtons() {
   buttons.forEach(button => {
     button.addEventListener("click", () => {
-      updateResult(button.dataset.operation);
+      activeOperation = button.dataset.operation;
+      updateResult(activeOperation);
     });
   });
 }
 
 function bindReset() {
   resetButton.addEventListener("click", () => {
-    inputA.value = 0;
-    inputB.value = 0;
-    updateResult("add");
+    const inputs = Array.from(inputContainer.querySelectorAll("[data-basic-input]"));
+    inputs.slice(2).forEach(input => input.closest(".input-row")?.remove());
+
+    const remainingInputs = Array.from(inputContainer.querySelectorAll("[data-basic-input]"));
+    remainingInputs.forEach((input, index) => {
+      input.value = defaultValues[index] ?? 0;
+    });
+
+    updateRemoveButtonState();
+    activeOperation = "add";
+    updateResult(activeOperation);
   });
+}
+
+function updateRemoveButtonState() {
+  const inputCount = inputContainer.querySelectorAll("[data-basic-input]").length;
+  removeInputButton.disabled = inputCount <= 2;
+}
+
+function addInputRow() {
+  const inputCount = inputContainer.querySelectorAll("[data-basic-input]").length;
+  const nextIndex = inputCount + 1;
+  const wrapper = document.createElement("div");
+  wrapper.className = "input-row";
+
+  const label = document.createElement("label");
+  label.htmlFor = `basic-value-${nextIndex}`;
+  label.textContent = `Number ${nextIndex}`;
+
+  const input = document.createElement("input");
+  input.type = "number";
+  input.id = `basic-value-${nextIndex}`;
+  input.value = "";
+  input.dataset.basicInput = "true";
+
+  wrapper.append(label, input);
+  inputContainer.append(wrapper);
+  updateRemoveButtonState();
+  updateResult(activeOperation);
+}
+
+function removeInputRow() {
+  const rows = Array.from(inputContainer.querySelectorAll(".input-row"));
+  if (rows.length <= 2) {
+    updateRemoveButtonState();
+    return;
+  }
+
+  const lastRow = rows[rows.length - 1];
+  lastRow.remove();
+  updateRemoveButtonState();
+  updateResult(activeOperation);
+}
+
+function bindInputControls() {
+  addInputButton.addEventListener("click", addInputRow);
+  removeInputButton.addEventListener("click", removeInputRow);
+  updateRemoveButtonState();
 }
 
 bindButtons();
 bindReset();
-updateResult("add");
+bindInputControls();
+updateResult(activeOperation);

--- a/public/calculators/math/percentage-calculator/index.html
+++ b/public/calculators/math/percentage-calculator/index.html
@@ -1,176 +1,88 @@
-<p class="helper">Select a mode to perform different percentage calculations.</p>
+<div class="calculator-ui">
+  <p class="helper">Select a mode to perform different percentage calculations.</p>
 
-<div class="mode-selector" role="tablist" aria-label="Calculation modes">
-  <button class="mode-button active" data-mode="increase" role="tab" aria-selected="true">
-    Percentage Increase
-  </button>
-  <button class="mode-button" data-mode="decrease" role="tab" aria-selected="false">
-    Percentage Decrease
-  </button>
-  <button class="mode-button" data-mode="what-percent" role="tab" aria-selected="false">
-    What % of what
-  </button>
-  <button class="mode-button" data-mode="percent-of" role="tab" aria-selected="false">
-    What is X% of Y
-  </button>
-</div>
-
-<!-- Percentage Increase -->
-<div class="input-section active" data-mode="increase" role="tabpanel">
-  <div class="input-stack">
-    <div>
-      <label for="increase-original">Original value</label>
-      <input id="increase-original" type="number" value="80" step="any" />
-    </div>
-    <div>
-      <label for="increase-new">New value</label>
-      <input id="increase-new" type="number" value="100" step="any" />
-    </div>
+  <div class="mode-selector" role="tablist" aria-label="Calculation modes">
+    <button class="mode-button active" data-mode="increase" role="tab" aria-selected="true">
+      Percentage Increase
+    </button>
+    <button class="mode-button" data-mode="decrease" role="tab" aria-selected="false">
+      Percentage Decrease
+    </button>
+    <button class="mode-button" data-mode="what-percent" role="tab" aria-selected="false">
+      What % of what
+    </button>
+    <button class="mode-button" data-mode="percent-of" role="tab" aria-selected="false">
+      What is X% of Y
+    </button>
   </div>
-  <button type="button" class="calculate" data-calculate="increase">Calculate</button>
-</div>
 
-<!-- Percentage Decrease -->
-<div class="input-section" data-mode="decrease" role="tabpanel">
-  <div class="input-stack">
-    <div>
-      <label for="decrease-original">Original value</label>
-      <input id="decrease-original" type="number" value="100" step="any" />
+  <!-- Percentage Increase -->
+  <div class="input-section active" data-mode="increase" role="tabpanel">
+    <div class="input-stack">
+      <div>
+        <label for="increase-original">Original value</label>
+        <input id="increase-original" type="number" value="80" step="any" />
+      </div>
+      <div>
+        <label for="increase-new">New value</label>
+        <input id="increase-new" type="number" value="100" step="any" />
+      </div>
     </div>
-    <div>
-      <label for="decrease-new">New value</label>
-      <input id="decrease-new" type="number" value="75" step="any" />
-    </div>
+    <button type="button" class="calculate calculator-button" data-calculate="increase">
+      Calculate
+    </button>
   </div>
-  <button type="button" class="calculate" data-calculate="decrease">Calculate</button>
-</div>
 
-<!-- What % of what -->
-<div class="input-section" data-mode="what-percent" role="tabpanel">
-  <div class="input-stack">
-    <div>
-      <label for="what-percent-part">Part value</label>
-      <input id="what-percent-part" type="number" value="25" step="any" />
+  <!-- Percentage Decrease -->
+  <div class="input-section" data-mode="decrease" role="tabpanel">
+    <div class="input-stack">
+      <div>
+        <label for="decrease-original">Original value</label>
+        <input id="decrease-original" type="number" value="100" step="any" />
+      </div>
+      <div>
+        <label for="decrease-new">New value</label>
+        <input id="decrease-new" type="number" value="75" step="any" />
+      </div>
     </div>
-    <div>
-      <label for="what-percent-whole">Whole value</label>
-      <input id="what-percent-whole" type="number" value="200" step="any" />
-    </div>
+    <button type="button" class="calculate calculator-button" data-calculate="decrease">
+      Calculate
+    </button>
   </div>
-  <button type="button" class="calculate" data-calculate="what-percent">Calculate</button>
-</div>
 
-<!-- What is X% of Y -->
-<div class="input-section" data-mode="percent-of" role="tabpanel">
-  <div class="input-stack">
-    <div>
-      <label for="percent-of-percent">Percentage (%)</label>
-      <input id="percent-of-percent" type="number" value="15" step="any" />
+  <!-- What % of what -->
+  <div class="input-section" data-mode="what-percent" role="tabpanel">
+    <div class="input-stack">
+      <div>
+        <label for="what-percent-part">Part value</label>
+        <input id="what-percent-part" type="number" value="25" step="any" />
+      </div>
+      <div>
+        <label for="what-percent-whole">Whole value</label>
+        <input id="what-percent-whole" type="number" value="200" step="any" />
+      </div>
     </div>
-    <div>
-      <label for="percent-of-base">Base value</label>
-      <input id="percent-of-base" type="number" value="80" step="any" />
-    </div>
+    <button type="button" class="calculate calculator-button" data-calculate="what-percent">
+      Calculate
+    </button>
   </div>
-  <button type="button" class="calculate" data-calculate="percent-of">Calculate</button>
+
+  <!-- What is X% of Y -->
+  <div class="input-section" data-mode="percent-of" role="tabpanel">
+    <div class="input-stack">
+      <div>
+        <label for="percent-of-percent">Percentage (%)</label>
+        <input id="percent-of-percent" type="number" value="15" step="any" />
+      </div>
+      <div>
+        <label for="percent-of-base">Base value</label>
+        <input id="percent-of-base" type="number" value="80" step="any" />
+      </div>
+    </div>
+    <button type="button" class="calculate calculator-button" data-calculate="percent-of">
+      Calculate
+    </button>
+  </div>
+
+  <div class="result" id="percentage-result" aria-live="polite"></div>
 </div>
-
-<div class="result" id="percentage-result" aria-live="polite"></div>
-
-<style>
-  label {
-    font-size: 14px;
-    color: var(--muted-text);
-    display: block;
-    margin-bottom: 6px;
-  }
-
-  input[type="number"] {
-    width: 100%;
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: 1px solid var(--border-color);
-    font-size: 16px;
-  }
-
-  .mode-selector {
-    display: flex;
-    gap: 8px;
-    margin-bottom: 20px;
-    flex-wrap: wrap;
-  }
-
-  .mode-button {
-    padding: 8px 16px;
-    border-radius: 8px;
-    border: 1px solid var(--border-color);
-    background: var(--panel-bg);
-    color: #1f2937;
-    font-size: 14px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s;
-  }
-
-  .mode-button:hover {
-    background: #f1f5f9;
-  }
-
-  .mode-button.active {
-    background: #2563eb;
-    color: #fff;
-    border-color: #2563eb;
-  }
-
-  .input-section {
-    display: none;
-    animation: fadeIn 0.3s;
-  }
-
-  .input-section.active {
-    display: block;
-  }
-
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
-
-  .input-stack {
-    display: grid;
-    gap: 16px;
-    margin-bottom: 16px;
-    min-height: 160px;
-  }
-
-  button.calculate {
-    padding: 10px 12px;
-    border-radius: 10px;
-    border: none;
-    background: #2563eb;
-    color: #fff;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
-  }
-
-  .result {
-    margin-top: 18px;
-    font-size: 18px;
-    font-weight: 600;
-    min-height: 60px;
-  }
-
-  .result-detail {
-    font-size: 14px;
-    color: var(--muted-text);
-    margin-top: 8px;
-    font-weight: 400;
-  }
-
-  .helper {
-    color: var(--muted-text);
-    margin-bottom: 16px;
-    font-size: 14px;
-  }
-</style>

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Layout shell for calchowmuch.com" />
     <link rel="stylesheet" href="assets/css/base.css" />
     <link rel="stylesheet" href="assets/css/layout.css" />
+    <link rel="stylesheet" href="assets/css/calculator.css" />
   </head>
   <body>
     <div class="page">

--- a/requirements/CODING_STANDARDS.MD
+++ b/requirements/CODING_STANDARDS.MD
@@ -30,6 +30,7 @@ Coding Standards (Corrected for HTML/CSS/JS) NON-NEGOTIABLE
     Calculator UI styling belongs in shared calculator stylesheet(s).
     Avoid inline styles in calculator HTML.
     Do not duplicate CSS rules across calculator folders.
+    Default calculator input and button sizing must be defined in shared calculator styles and reused across calculators.
 
     Testing Standards (MUST FOLLOW)
     =================================


### PR DESCRIPTION
### Motivation
- Make the Basic calculator UI match the Percentage calculators by standardizing input and button sizes and placing the `Reset` control in the same top toolbar position. 
- Allow the Basic calculator to operate on more than two numbers (add/remove inputs) so it can perform `Add`, `Subtract`, `Multiply`, and `Divide` across multiple values. 
- Enforce a shared, reusable sizing rule for calculator inputs and buttons in the project coding standards so all calculators remain consistent.

### Description
- Added a shared stylesheet `public/assets/css/calculator.css` and linked it from `public/index.html` to define default input/button sizing and shared calculator UI classes (`.calculator-ui`, `.calculator-button`, etc.).
- Updated Basic calculator markup at `public/calculators/math/basic/index.html` to a top-aligned toolbar with `Reset`, `Add number`, and `Remove number` controls and replaced the two fixed inputs with an input stack (`#basic-inputs`) of numbered inputs using `data-basic-input` attributes.
- Reworked Basic calculator logic in `public/calculators/math/basic/module.js` to support dynamic input rows, `add`/`remove` input handlers, a `calculateMultiple` routine that reduces over many values for each operation, and updated reset behavior; preserved safe handling of divide-by-zero.
- Aligned `public/calculators/math/percentage-calculator/index.html` markup to use the new shared calculator classes so inputs and buttons match the standardized sizing.
- Updated `requirements/CODING_STANDARDS.MD` to require default calculator input and button sizing be declared in a shared calculator stylesheet and reused across calculators.

### Testing
- Launched a local static server with `python -m http.server` to serve `/public`, which started successfully and served static assets. 
- Verified `config/navigation.json` and the new stylesheet with `curl`/`HEAD` requests which returned expected responses (navigation and `assets/css/calculator.css` available). 
- Attempted end-to-end rendering checks with Playwright to capture screenshots, but the Playwright runs timed out or observed `404` responses during navigation and therefore those browser screenshot attempts failed; no unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966c328e07c8325b1ec55d25964c32e)